### PR TITLE
feat(count): count the found rows, #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,5 +648,27 @@ const Dare = require('dare');
 const dare = new Dare();
 
 dare.MAX_LIMIT = 1000000;
+
 ```
+
+### Retrieving the number of results in a SELECT with LIMIT
+
+Setting an additional option `count` will mark the query to be counted.
+
+
+```js
+
+// Get some data using the `count: true` attribute
+const users = await dare.get({
+	table: 'users',
+	fields: ['name'],
+	limit: 10,
+	count: true
+});
+
+// Call `dare.count()` to retrive the number of results the previous query would have obtained had it not been limited.
+const count = await dare.count();
+```
+
+Behind the scenes this uses `SQL_CALC_FOUND_ROWS` and `FOUND_ROWS()`
 

--- a/src/get.js
+++ b/src/get.js
@@ -60,7 +60,7 @@ function buildQuery(opts) {
 	const sql_limit = `LIMIT ${opts.start ? `${opts.start},` : ''}${opts.limit}`;
 
 	// Found rows
-	const sql_found_rows = opts.found_rows ? 'SQL_CALC_FOUND_ROWS ' : '';
+	const sql_count = opts.count ? 'SQL_CALC_FOUND_ROWS ' : '';
 
 	// SubQuery
 	const is_subquery = opts.is_subquery;
@@ -181,7 +181,7 @@ function buildQuery(opts) {
 
 
 	// Put it all together
-	const sql = `SELECT ${sql_found_rows}${sql_fields.toString()}
+	const sql = `SELECT ${sql_count}${sql_fields.toString()}
 				 FROM ${sql_table} ${sql_alias}
 						${sql_joins.join('\n')}
 				 ${sql_filter.length ? 'WHERE' : ''}

--- a/src/get.js
+++ b/src/get.js
@@ -49,6 +49,9 @@ function buildQuery(opts) {
 	// Limit
 	const sql_limit = `LIMIT ${opts.start ? `${opts.start},` : '' }${opts.limit}`;
 
+	// Found rows
+	const sql_found_rows = opts.found_rows ? 'SQL_CALC_FOUND_ROWS ' : '';
+
 	// SubQuery
 	const is_subquery = opts.is_subquery;
 
@@ -145,7 +148,7 @@ function buildQuery(opts) {
 
 
 	// Put it all together
-	const sql = `SELECT ${sql_fields.toString()}
+	const sql = `SELECT ${sql_found_rows}${sql_fields.toString()}
 				 FROM ${sql_table} ${sql_alias}
 						${sql_joins.join('\n')}
 				 ${sql_filter.length ? 'WHERE' : ''}

--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,12 @@ Dare.prototype.sql = async function sql(sql, prepared) {
 
 };
 
+Dare.prototype.count = async function sql_count() {
+
+	const [{count}] = await promisify(this.execute)('SELECT FOUND_ROWS() AS count');
+	return count;
+
+};
 
 Dare.prototype.get = async function get(table, fields, filter, opts = {}) {
 
@@ -142,6 +148,7 @@ Dare.prototype.get = async function get(table, fields, filter, opts = {}) {
 	return _this.after(resp);
 
 };
+
 
 Dare.prototype.patch = async function patch(table, filter, body, opts = {}) {
 

--- a/test/specs/get-count.js
+++ b/test/specs/get-count.js
@@ -1,0 +1,78 @@
+
+
+// Test Generic DB functions
+const sqlEqual = require('../lib/sql-equal');
+
+describe('get - found rows', () => {
+
+	let dare;
+
+	beforeEach(() => {
+
+		dare = new Dare();
+		dare.execute = () => {
+
+			throw new Error('Should not execute');
+
+		};
+
+	});
+
+	it('should contain the function dare.count()', () => {
+
+		expect(dare.count).to.be.a('function');
+
+	});
+
+	it('dare.count() should execute FOUND_ROWS() and return a single number', async () => {
+
+		const count = 10;
+		dare.execute = (query, callback) => {
+
+			const expected = `
+				SELECT FOUND_ROWS() AS count
+			`;
+
+			sqlEqual(query, expected);
+
+			callback(null, [{count}]);
+
+		};
+
+		const resp = await dare.count();
+
+		expect(resp).to.eql(count);
+
+	});
+
+	it('should return `count` when defined in request options', async () => {
+
+		const data = [{name: 'hello'}];
+		dare.execute = (query, callback) => {
+
+			const expected = `
+				SELECT SQL_CALC_FOUND_ROWS a.name
+				FROM test a
+				LIMIT 10
+			`;
+
+			sqlEqual(query, expected);
+
+			callback(null, data);
+
+		};
+
+		const resp = await dare
+			.get({
+				table: 'test',
+				fields: ['name'],
+				limit: 10,
+				count: true
+			});
+
+		expect(resp).to.eql(data);
+
+	});
+
+});
+

--- a/test/specs/get.js
+++ b/test/specs/get.js
@@ -405,35 +405,6 @@ describe('get', () => {
 
 		});
 
-		it('should return found_rows when defined in request options', async () => {
-
-			const data = [{name: 'hello'}];
-			dare.execute = (query, callback) => {
-
-				const expected = `
-					SELECT SQL_CALC_FOUND_ROWS a.name
-					FROM test a
-					LIMIT 10
-				`;
-
-				sqlEqual(query, expected);
-
-				callback(null, data);
-
-			};
-
-			const resp = await dare
-				.get({
-					table: 'test',
-					fields: ['name'],
-					limit: 10,
-					found_rows: true
-				});
-
-			expect(resp).to.eql(data);
-
-		});
-
 	});
 
 });

--- a/test/specs/get.js
+++ b/test/specs/get.js
@@ -344,6 +344,34 @@ describe('get', () => {
 			expect(resp).to.eql({_count: 10});
 
 		});
+
+		it('should return found_rows when defined in request options', async() => {
+
+			const data = [{name: 'hello'}];
+			dare.execute = (query, callback) => {
+
+				const expected = `
+					SELECT SQL_CALC_FOUND_ROWS a.name
+					FROM test a
+					LIMIT 10
+				`;
+
+				sqlEqual(query, expected);
+
+				callback(null, data);
+			};
+
+			const resp = await dare
+				.get({
+					table: 'test',
+					fields: ['name'],
+					limit: 10,
+					found_rows: true
+				});
+
+			expect(resp).to.eql(data);
+
+		});
 	});
 });
 


### PR DESCRIPTION
### Retrieving the number of results in a SELECT with LIMIT
 Setting an additional option `count` will mark the query to be counted.
 ```js
 // Get some data using the `count: true` attribute
const users = await dare.get({
	table: 'users',
	fields: ['name'],
	limit: 10,
	count: true
});
 // Call `dare.count()` to retrive the number of results the previous query would have obtained had it not been limited.
const count = await dare.count();
```
 Behind the scenes this uses `SQL_CALC_FOUND_ROWS` and `FOUND_ROWS()`
