### PR TITLE
docs: Fix the name of the option duplicate_keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ This generates `INSERT INTO user (name, profession) VALUES ('Andrew', 'Mad Scien
 
 | Prop          | Type             | Description
 |---------------|------------------|----------------
-| duplicate_key | 'ignore'         | Inserts SQL 'IGNORE' option
+| duplicate_keys | 'ignore'         | Inserts SQL 'IGNORE' option
 | duplicate_keys_update | Array(field1, field2, ...) | Appends `ON DUPLICATE KEYS UPDATE field1=VALUES(field1)`
 
 


### PR DESCRIPTION
Fix the typo on the name of the option `duplicate_keys` which can be used to ignore duplicate entries in a table when doing a bulk insert