### PR TITLE
docs: Fix typo in require

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm i dare --save
 Create an instance of Dare with some options
 
 ```javascript
-const Dare = reqire('dare');
+const Dare = require('dare');
 
 const options = {
 	schema


### PR DESCRIPTION
Replace `reqire` with `require` in the code snippet of how to include Dare in your project