### PR TITLE
fix(datetime): cast datetime fields in ISO format

### DIFF
--- a/src/utils/field_reducer.js
+++ b/src/utils/field_reducer.js
@@ -151,7 +151,7 @@ function fieldMapping(field, label, tableSchema, fieldsArray) {
 	const {field_name, prefix, suffix} = checkFormat(field);
 
 	// Get the schema entry for the field
-	const {handler, alias} = getFieldAttributes(tableSchema[field_name]);
+	const {handler, alias, type} = getFieldAttributes(tableSchema[field_name]);
 
 	// Does this field have a handler in the schema
 	if (handler) {
@@ -164,17 +164,23 @@ function fieldMapping(field, label, tableSchema, fieldsArray) {
 	}
 
 	// Does the field map to another key name...
-	else if (alias) {
+	if (alias) {
 
 		// Use the original name, defined by the key_definition
-		return {
-			[label]: rewrap_field(alias, prefix, suffix)
-		};
+		field = rewrap_field(alias, prefix, suffix);
+
+	}
+
+
+	// Default format datetime field as an ISO string...
+	if (type === 'datetime' && !prefix) {
+
+		field = `DATE_FORMAT(${field},'%Y-%m-%dT%TZ')`;
 
 	}
 
 	// If this is a object-field definition
-	else if (isObj) {
+	if (isObj || label !== field) {
 
 		// Add the field to the array
 		return {

--- a/test/specs/field_reducer.js
+++ b/test/specs/field_reducer.js
@@ -168,5 +168,24 @@ describe('Field Reducer', () => {
 
 	});
 
+	it('should format datetime fields', () => {
+
+		const table_schema = {
+			created: {
+				type: 'datetime'
+			}
+		};
+
+		// Curry the field_reducer
+		const fr = field_reducer.call({}, 'created', {}, table_schema);
+
+		// Call the field with the
+		const f = ['created'].reduce(fr, []);
+
+		// Expect the formatted list of fields to be identical to the inputted value
+		expect(f[0]).to.have.property('created', 'DATE_FORMAT(created,\'%Y-%m-%dT%TZ\')');
+
+	});
+
 });
 


### PR DESCRIPTION
Fixes #36 

- Wraps fields defined as **`type: datetime`** with `DATE_FORMAT(${field},'%Y-%m-%dT%TZ')` casting them to an ISO datetime string. see https://stackoverflow.com/questions/9321809/format-date-in-mysql-select-as-iso-8601