### PR TITLE
fix(datetype): return ISO string with microseconds, #36

### DIFF
--- a/src/utils/field_reducer.js
+++ b/src/utils/field_reducer.js
@@ -175,7 +175,7 @@ function fieldMapping(field, label, tableSchema, fieldsArray) {
 	// Default format datetime field as an ISO string...
 	if (type === 'datetime' && !prefix) {
 
-		field = `DATE_FORMAT(${field},'%Y-%m-%dT%TZ')`;
+		field = `DATE_FORMAT(${field},'%Y-%m-%dT%T.%fZ')`;
 
 	}
 

--- a/src/utils/unwrap_field.js
+++ b/src/utils/unwrap_field.js
@@ -20,7 +20,7 @@ module.exports = function unwrap_field(expression, formatter = (obj => obj)) {
 
 			// Split out comma variables
 			let int_m;
-			while ((int_m = str.match(/(.*)(,\s*((["'])?[a-z0-9%_\-\s]*\4))$/i))) {
+			while ((int_m = str.match(/(.*)(,\s*((["'])?[a-z0-9%_\-.\s]*\4))$/i))) {
 
 				str = int_m[1];
 				suffix = int_m[2] + suffix;

--- a/test/specs/field_reducer.js
+++ b/test/specs/field_reducer.js
@@ -183,7 +183,7 @@ describe('Field Reducer', () => {
 		const f = ['created'].reduce(fr, []);
 
 		// Expect the formatted list of fields to be identical to the inputted value
-		expect(f[0]).to.have.property('created', 'DATE_FORMAT(created,\'%Y-%m-%dT%TZ\')');
+		expect(f[0]).to.have.property('created', 'DATE_FORMAT(created,\'%Y-%m-%dT%T.%fZ\')');
 
 	});
 

--- a/test/specs/get-datatypes.js
+++ b/test/specs/get-datatypes.js
@@ -22,12 +22,12 @@ describe('get - datatypes', () => {
 
 	it('should return `created_time` using DATE_FORMAT', async () => {
 
-		const created_time = '2019-09-03T12:00:00Z';
+		const created_time = '2019-09-03T12:00:00.000000Z';
 
 		dare.execute = async query => {
 
 			const expected = `
-				SELECT DATE_FORMAT(a.created_time,'%Y-%m-%dT%TZ') AS 'created_time'
+				SELECT DATE_FORMAT(a.created_time,'%Y-%m-%dT%T.%fZ') AS 'created_time'
 				FROM users a
 				LIMIT 1
 			`;

--- a/test/specs/get-join.js
+++ b/test/specs/get-join.js
@@ -50,7 +50,7 @@ describe('get - request object', () => {
 
 			const expected = `
 
-				SELECT DATE_FORMAT(a.created_time, '%Y-%m-%dT%TZ') AS 'created_time', COUNT(*) AS '_count', c.id AS 'asset.id', c.name AS 'asset.name', DATE(c.updated_time) AS 'asset.last_updated'
+				SELECT DATE_FORMAT(a.created_time, '%Y-%m-%dT%T.%fZ') AS 'created_time', COUNT(*) AS '_count', c.id AS 'asset.id', c.name AS 'asset.name', DATE(c.updated_time) AS 'asset.last_updated'
 				FROM activityEvents a
 					LEFT JOIN activitySession b ON (b.id = a.session_id)
 					LEFT JOIN apps c ON (c.id = a.ref_id)


### PR DESCRIPTION
- return iso string with microseconds e.g. "2016-10-11T17:18:52.000000Z" note the 6 zeros!

I would have preferred milliseconds but that is not available option in https://dev.mysql.com/doc/refman/5.6/en/date-and-time-functions.html#function_date-format