### PR TITLE
feat(field processing): define restrictions on field definitions

### DIFF
--- a/src/utils/unwrap_field.js
+++ b/src/utils/unwrap_field.js
@@ -20,7 +20,18 @@ module.exports = function unwrap_field(expression, formatter = (obj => obj)) {
 
 			// Split out comma variables
 			let int_m;
-			while ((int_m = str.match(/(.*)(,\s*((["'])?[a-z0-9%_\-\s]*\4))$/i))) {
+			while ((int_m = str.match(/(.*)(,\s*((["'])?[a-z0-9%._\s-]*\4))$/i))) {
+
+				/*
+				 * Is there an unquoted parameter
+				 * Ensure there are no lowercase strings (e.g. column names)
+				 */
+				if (!int_m[4] && int_m[3] && int_m[3].match(/[a-z]/)) {
+
+					// Is this a valid field
+					throw new DareError(DareError.INVALID_REFERENCE, `The field definition '${expression}' is invalid.`);
+
+				}
 
 				str = int_m[1];
 				suffix = int_m[2] + suffix;
@@ -49,7 +60,7 @@ module.exports = function unwrap_field(expression, formatter = (obj => obj)) {
 		}
 
 		// Remove any additional prefix in a function.. i.e. "YEAR_MONTH FROM " from "EXTRACT(YEAR_MONTH FROM field)"
-		if (prefix && str && (m = str.match(/^[a-z_\s]+\s/i))) {
+		if (prefix && str && (m = str.match(/^[A-Z_\s]+\s/))) {
 
 			prefix += m[0];
 			str = str.slice(m[0].length);

--- a/test/specs/unwrap_field.js
+++ b/test/specs/unwrap_field.js
@@ -4,6 +4,7 @@
  */
 
 const unwrap_field = require('../../src/utils/unwrap_field');
+const DareError = require('../../src/utils/error');
 
 describe('utils/unwrap_field', () => {
 
@@ -11,6 +12,8 @@ describe('utils/unwrap_field', () => {
 	[
 		'field',
 		'DATE(field)',
+		'DATE_FORMAT(field, "%Y-%m-%dT%T.%fZ")',
+		'DATE_SUB(field, INTERVAL 10 DAY)',
 		'COUNT(DISTINCT field)',
 		'GROUP_CONCAT(DISTINCT field)',
 		'MAX(DAY(field))',
@@ -35,6 +38,22 @@ describe('utils/unwrap_field', () => {
 
 			// Expect the formatted list of fields to be identical to the inputted value
 			expect(unwrapped.field).to.eql('field');
+
+		});
+
+	});
+
+	// Should unwrap SQL Formating to underlying column name
+	[
+		'field(',
+		'CONCAT(field, secret)',
+		'DATE_FORMAT(field, '
+	].forEach(test => {
+
+		it(`where ${JSON.stringify(test)}`, () => {
+
+			// Expect the formatted list of fields to be identical to the inputted value
+			expect(unwrap_field.bind(null, test)).to.throw(DareError);
 
 		});
 


### PR DESCRIPTION
- Allow `.` characters in function declarations. e.g. `DATE_FORMAT(field, "%Y-%m-%dT%T.%fZ")` (note the `.` to denote Milliseconds)
- Prevent lowercase strings in unquoted field values:
   - Prevents values which could be interpolated as a table field e.g. `CONCAT(field, secret)`, where `secret` should not be accessible.
   - `DATE_SUB(field, INTERVAL 1 DAY)` is ok as the mysql command `INTERVAL 1 DAY` is all in uppercase.
   - `ROUND(field, 2)` is ok as the secondary value is just a number
   - `IFNULL(field, "yes")` is ok because `yes` is quoted.

