### PR TITLE
fix(buffer): format response Buffer values

### DIFF
--- a/src/utils/JSONparse.js
+++ b/src/utils/JSONparse.js
@@ -5,9 +5,11 @@ module.exports = value => {
 
 		// Ensure Buffers are converted..
 		if (Buffer.isBuffer(value)) {
+
 			value = value.toString();
+
 		}
-	
+
 		return JSON.parse(value
 			.replace(/\t/g, '\\t')
 			.replace(/\n/g, '\\n')

--- a/src/utils/JSONparse.js
+++ b/src/utils/JSONparse.js
@@ -3,6 +3,11 @@ module.exports = value => {
 
 	try {
 
+		// Ensure Buffers are converted..
+		if (Buffer.isBuffer(value)) {
+			value = value.toString();
+		}
+	
 		return JSON.parse(value
 			.replace(/\t/g, '\\t')
 			.replace(/\n/g, '\\n')

--- a/test/specs/response_handler.js
+++ b/test/specs/response_handler.js
@@ -44,7 +44,8 @@ describe('response_handler', () => {
 
 		const data = dare.response_handler([{
 			'field': 'value',
-			'assoc.id,assoc.name': '["1","a"]'
+			'assoc.id,assoc.name': '["1","a"]',
+			'a,b': Buffer.from('["1","2"]')
 		}]);
 
 		expect(data).to.be.an('array');
@@ -53,7 +54,9 @@ describe('response_handler', () => {
 			assoc: {
 				id: '1',
 				name: 'a'
-			}
+			},
+			a: '1',
+			b: '2'
 		});
 
 	});
@@ -189,4 +192,5 @@ describe('response_handler', () => {
 
 	});
 
+	
 });

--- a/test/specs/response_handler.js
+++ b/test/specs/response_handler.js
@@ -192,5 +192,5 @@ describe('response_handler', () => {
 
 	});
 
-	
+
 });


### PR DESCRIPTION
Response Handler could not format values which were returned as `Buffer` objects. Not sure why integrations are returning Buffer. But resolved here nonetheless

```
TypeError: Cannot read property '0' of undefined
      at label.split.forEach (src/response_handler.js:44:50)
      at Array.forEach (<anonymous>)
      at Dare.formatHandler (src/response_handler.js:42:21)
      at Array.map (<anonymous>)
      at Dare.responseHandler [as response_handler] (src/response_handler.js:9:14)
      at Context.it (test/specs/response_handler.js:45:21)
```