### PR TITLE
fix: allow redefining arrays of field keys

### DIFF
--- a/src/utils/field_reducer.js
+++ b/src/utils/field_reducer.js
@@ -40,11 +40,6 @@ module.exports = function fieldReducer(current_address, join, table_schema = {})
 				join[key].fields = [];
 
 			}
-			else if (!Array.isArray(join[key].fields)) {
-
-				join[key].fields = [join[key].fields];
-
-			}
 
 			join[key].fields.push(d);
 			return true;
@@ -71,8 +66,13 @@ module.exports = function fieldReducer(current_address, join, table_schema = {})
 
 					}
 
+					/*
+					 * This key=>value object refers to another table as the value is an object itself
+					 * Add the object to the join table...
+					 */
 					join[key] = join[key] || {};
-					join[key].fields = value;
+					join[key].fields = join[key].fields || [];
+					join[key].fields.push(...(Array.isArray(value) ? value : [value]));
 
 				}
 				else {

--- a/test/specs/field_reducer.js
+++ b/test/specs/field_reducer.js
@@ -103,7 +103,6 @@ describe('Field Reducer', () => {
 				}]
 			]
 
-
 		].forEach(test => {
 
 			const input = test[0]; // Test request fields array to process

--- a/test/specs/get-join.js
+++ b/test/specs/get-join.js
@@ -170,6 +170,49 @@ describe('get - request object', () => {
 
 		});
 
+
+		it('should allow multiple definitions of the same thing', async () => {
+
+			dare.sql = async query => {
+
+				const key = 'email1,users_email.email,users_email.emailnest';
+
+				expect(query).to.contain(key);
+
+				return [{
+					[key]: '["a@b.com","a@b.com","a@b.com"]'
+				}];
+
+			};
+
+			/*
+			 * We should get back both structures
+			 */
+			const res = await dare.get({
+				table: 'users',
+				fields: [
+					{
+						'email1': 'users_email.email'
+					},
+					{
+						'users_email': ['email']
+					},
+					{
+						'users_email': {
+							'emailnest': 'email'
+						}
+					}
+				]
+			});
+
+			expect(res).to.have.property('email1');
+			expect(res.users_email)
+				.to.have.property('email');
+			expect(res.users_email)
+				.to.have.property('emailnest');
+
+		});
+
 	});
 
 	describe('filter', () => {


### PR DESCRIPTION
Fixes #43

Does not override field values as it did before when a new one was an object.