### PR TITLE
Fix nested generated fields

### DIFF
--- a/src/format/field_reducer.js
+++ b/src/format/field_reducer.js
@@ -10,13 +10,13 @@ const jsonParse = require('../utils/JSONparse');
 /**
  * Return a reducer function deriving local props and nested props
  * @param {object} opts - Options
- * @param {string} opts.current_path - Current address path of the resource
+ * @param {string} opts.field_alias_path - Current address path of the resource
  * @param {Function} opts.extract - Function for handling the extraction of content
  * @param {object} opts.table_schema - Table schema/Data model
  * @param {object} opts.dareInstance - Instance of Dare which is calling this
  * @returns {Function} Fields Reducer function
  */
-module.exports = function fieldReducer({current_path, extract, table_schema, dareInstance}) {
+module.exports = function fieldReducer({field_alias_path, extract, table_schema, dareInstance}) {
 
 	const addToJoin = (field, label) => {
 
@@ -29,7 +29,7 @@ module.exports = function fieldReducer({current_path, extract, table_schema, dar
 		 * Then we'd break down the new address "parent.tbl.field" => "parent.tbl." => "parent."
 		 * And see that that actually the path is the bit we've removed... aka tbl.field
 		 */
-		const path = fieldRelativePath(current_path, address);
+		const path = fieldRelativePath(field_alias_path, address);
 		const relative = path.split('.');
 
 		if (relative.length > 1) {
@@ -85,7 +85,13 @@ module.exports = function fieldReducer({current_path, extract, table_schema, dar
 
 					}
 
-					fieldsArray.push(fieldMapping(value, key, table_schema, fieldsArray, dareInstance));
+					const formattedField = fieldMapping(value, key, table_schema, fieldsArray, field_alias_path, dareInstance);
+
+					if (formattedField) {
+
+						fieldsArray.push(formattedField);
+
+					}
 
 				}
 
@@ -108,7 +114,13 @@ module.exports = function fieldReducer({current_path, extract, table_schema, dar
 
 			}
 
-			fieldsArray.push(fieldMapping(field, null, table_schema, fieldsArray, dareInstance));
+			const formattedField = fieldMapping(field, null, table_schema, fieldsArray, field_alias_path, dareInstance);
+
+			if (formattedField) {
+
+				fieldsArray.push(formattedField);
+
+			}
 
 		}
 
@@ -128,10 +140,11 @@ module.exports = function fieldReducer({current_path, extract, table_schema, dar
  * @param {string|null} label - Optional label, or null
  * @param {object} tableSchema - Schema of the current table
  * @param {Array} fieldsArray - An array of all the fields to use with generated functions
+ * @param {string} field_alias_path - Current address path of the resource
  * @param {object} dareInstance - An instance of the current Dare object
  * @returns {string|object} The augemented field expression
  */
-function fieldMapping(field, label, tableSchema, fieldsArray, dareInstance) {
+function fieldMapping(field, label, tableSchema, fieldsArray, field_alias_path, dareInstance) {
 
 	// Try to return an object
 	const isObj = Boolean(label);
@@ -160,9 +173,26 @@ function fieldMapping(field, label, tableSchema, fieldsArray, dareInstance) {
 	// Does this field have a handler in the schema
 	if (handler) {
 
+		// Generated fields
+		const generated_field = handler.call(dareInstance, fieldsArray);
+
+		// Is the generated field completely abstract?
+		if (typeof generated_field === 'function') {
+
+			// Add for post processing
+			dareInstance.generated_fields.push({
+				label,
+				field_alias_path,
+				handler: generated_field
+			});
+
+			return;
+
+		}
+
 		// Execute the handler, add the response to the field list
 		return {
-			[label]: handler.call(dareInstance, fieldsArray)
+			[label]: generated_field
 		};
 
 	}
@@ -186,9 +216,11 @@ function fieldMapping(field, label, tableSchema, fieldsArray, dareInstance) {
 	// Default format datetime field as an ISO string...
 	else if (type === 'json' && !prefix) {
 
-		// Add a function of the same name to retro-format the field
-		fieldsArray.push({
-			[label]: item => jsonParse(item[label]) || {}
+		// Add for post processing
+		dareInstance.generated_fields.push({
+			label,
+			field_alias_path,
+			handler: item => jsonParse(item[label]) || {}
 		});
 
 		// Continue...

--- a/src/format/field_reducer.js
+++ b/src/format/field_reducer.js
@@ -85,7 +85,7 @@ module.exports = function fieldReducer({current_path, extract, table_schema, dar
 
 					}
 
-					fieldsArray.push(fieldMapping(value, key, table_schema, fieldsArray));
+					fieldsArray.push(fieldMapping(value, key, table_schema, fieldsArray, dareInstance));
 
 				}
 

--- a/src/format_request.js
+++ b/src/format_request.js
@@ -91,6 +91,8 @@ async function format_request(options = {}, dareInstance) {
 	// Set the prefix if not already
 	options.field_alias_path = options.field_alias_path || '';
 
+	const {field_alias_path} = options;
+
 	// Current Path
 	const current_path = options.field_alias_path || `${options.alias}.`;
 
@@ -157,7 +159,7 @@ async function format_request(options = {}, dareInstance) {
 		const extract = extractJoined.bind(null, 'fields', true);
 
 		// Set reducer options
-		const reducer = fieldReducer({current_path, extract, table_schema, dareInstance});
+		const reducer = fieldReducer({field_alias_path, extract, table_schema, dareInstance});
 
 		// Return array of immediate props
 		options.fields = toArray(options.fields).reduce(reducer, []);

--- a/src/get.js
+++ b/src/get.js
@@ -11,8 +11,8 @@ module.exports = async function(opts) {
 	// Reset the alias
 	this.unique_alias_index = 0;
 
-	// Set the table_response_handlers
-	this.response_handlers = this.response_handlers || [];
+	// Set the generate_fields array
+	this.generated_fields = this.generated_fields || [];
 
 	// Define the buildQuery
 	this.buildQuery = buildQuery;
@@ -432,10 +432,13 @@ function traverse(item, is_subquery) {
 			// Have we got a generated field?
 			if (typeof expression === 'function') {
 
-				// Add this to the list
-				this.response_handlers.push(
-					setField.bind(this, !item.root && item.alias, label, expression)
-				);
+				// Add for post processing
+				this.generated_fields.push({
+					label,
+					field_alias_path: item.field_alias_path,
+					handler: expression
+				});
+
 				return;
 
 			}
@@ -546,18 +549,6 @@ function prepField(field) {
 		return [expression, label];
 
 	}
-
-}
-
-function setField(table, field, handler, obj) {
-
-	if (table) {
-
-		obj = obj[table];
-
-	}
-
-	obj[field] = handler.call(this, obj);
 
 }
 

--- a/src/get.js
+++ b/src/get.js
@@ -11,9 +11,6 @@ module.exports = async function(opts) {
 	// Reset the alias
 	this.unique_alias_index = 0;
 
-	// Set the generate_fields array
-	this.generated_fields = this.generated_fields || [];
-
 	// Define the buildQuery
 	this.buildQuery = buildQuery;
 
@@ -428,20 +425,6 @@ function traverse(item, is_subquery) {
 
 		// Yes, believe it or not but some queries do have them...
 		item.fields.map(prepField).forEach(([expression, label]) => {
-
-			// Have we got a generated field?
-			if (typeof expression === 'function') {
-
-				// Add for post processing
-				this.generated_fields.push({
-					label,
-					field_alias_path: item.field_alias_path,
-					handler: expression
-				});
-
-				return;
-
-			}
 
 			fields.push(field_format(expression, label, sql_alias, item.field_alias_path));
 

--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,9 @@ Dare.prototype.use = function(options = {}) {
 	// Create a new options, merging inheritted and new
 	inst.options = extend(clone(this.options), options);
 
+	// Set the generate_fields array
+	inst.generated_fields = [];
+
 	// Set SQL level states
 	inst.unique_alias_index = 0;
 	return inst;

--- a/src/response_handler.js
+++ b/src/response_handler.js
@@ -14,19 +14,17 @@ module.exports = function responseHandler(resp) {
 		let item = formatHandler(row);
 
 		// Add generate fields for generating fields etc...
-		if (this.generated_fields) {
 
-			this.generated_fields.forEach(obj => {
+		this.generated_fields.forEach(obj => {
 
-				// Split the address of the item up...
-				const address = obj.field_alias_path.split('.').filter(Boolean);
+			// Split the address of the item up...
+			const address = obj.field_alias_path.split('.').filter(Boolean);
 
-				// Generate the fields handler
-				generatedFieldsHandler({...obj, address, item}, dareInstance);
+			// Generate the fields handler
+			generatedFieldsHandler({...obj, address, item}, dareInstance);
 
-			});
+		});
 
-		}
 
 		// Add custom response_row_handler, for handling the record
 		if (this.response_row_handler) {

--- a/src/response_handler.js
+++ b/src/response_handler.js
@@ -5,16 +5,26 @@ const JSONparse = require('./utils/JSONparse');
 // Response
 module.exports = function responseHandler(resp) {
 
+	const dareInstance = this;
+
 	// Iterate over the response array and trigger formatting
 	return resp.reduce((items, row, index) => {
 
 		// Expand row...
 		let item = formatHandler(row);
 
-		// Add response handlers for generated fields etc...
-		if (this.response_handlers) {
+		// Add generate fields for generating fields etc...
+		if (this.generated_fields) {
 
-			this.response_handlers.forEach(callback => callback(item));
+			this.generated_fields.forEach(obj => {
+
+				// Split the address of the item up...
+				const address = obj.field_alias_path.split('.').filter(Boolean);
+
+				// Generate the fields handler
+				generatedFieldsHandler({...obj, address, item}, dareInstance);
+
+			});
 
 		}
 
@@ -169,5 +179,44 @@ function explodeKeyValue(obj, a, value) {
 	obj[key] = explodeKeyValue(obj[key], a, value);
 
 	return obj;
+
+}
+
+/**
+ * Generate Fields Handler
+ * @param {object} obj - Request Object
+ * @param {string} obj.label - Name of the property to be created
+ * @param {Function} obj.handler - Function to process the request
+ * @param {Array} obj.address - Paths of the item
+ * @param {obj} obj.item - Obj where the new prop will be appended
+ * @param {obj} dareInstance - Dare Instance
+ * @returns {void} Modifies the incoming request with new props
+ */
+function generatedFieldsHandler({label, handler, address, item}, dareInstance) {
+
+	if (address.length === 0) {
+
+		item[label] = handler.call(dareInstance, item);
+		return;
+
+	}
+
+	// Get the current position in the address
+	const [modelname] = address;
+
+	// Shift the item off the address, creating a new address
+	const next_address = address.slice(1);
+
+	// Get the nested object
+	const nested = item[modelname];
+
+	// Assuming it's a valid resource...
+	if (nested) {
+
+		// And treat single and array items the same for simplicity
+		(Array.isArray(nested) ? nested : [nested])
+			.forEach(item => generatedFieldsHandler({label, handler, address: next_address, item}, dareInstance));
+
+	}
 
 }

--- a/test/data/options.js
+++ b/test/data/options.js
@@ -25,6 +25,20 @@ module.exports = {
 				type: 'json'
 			},
 
+			/**
+			 * Url generated
+			 * @param {Array} fields - Array of current fields
+			 * @returns {string|Function} Can return a function or a field definition.
+			 */
+			url(fields) {
+
+				// This is a generated function
+				fields.push('id');
+
+				return ({id}) => `/user/${id}`;
+
+			},
+
 			/*
 			 * Date Type
 			 */

--- a/test/specs/field_reducer.js
+++ b/test/specs/field_reducer.js
@@ -7,9 +7,16 @@ const field_reducer = require('../../src/format/field_reducer');
 
 describe('Field Reducer', () => {
 
+	let dareInstance;
 
 	// Mock instance of Dare
-	const dareInstance = {};
+	beforeEach(() => {
+
+		dareInstance = {
+			generated_fields: []
+		};
+
+	});
 
 	describe('should split the current fields belonging to the current and joined tables', () => {
 
@@ -113,7 +120,7 @@ describe('Field Reducer', () => {
 			const expect_join_fields = test[2]; // Expect Joined fields
 
 			// Details about the current table...
-			const current_path = 'something.asset.';
+			const field_alias_path = 'something.asset.';
 			const table_schema = {};
 			const joined = {};
 			const extract = (key, value) => {
@@ -132,7 +139,7 @@ describe('Field Reducer', () => {
 			};
 
 			// Curry the field_reducer
-			const fr = field_reducer({current_path, extract, table_schema, dareInstance});
+			const fr = field_reducer({field_alias_path, extract, table_schema, dareInstance});
 
 
 			it(`where ${JSON.stringify(input)}`, () => {
@@ -171,10 +178,10 @@ describe('Field Reducer', () => {
 			}
 		};
 
-		const current_path = 'alias';
+		const field_alias_path = 'alias';
 
 		// Curry the field_reducer
-		const fr = field_reducer({current_path, table_schema, dareInstance});
+		const fr = field_reducer({field_alias_path, table_schema, dareInstance});
 
 		// Call the field with the
 		const f = ['generated_field'].reduce(fr, []);
@@ -192,10 +199,10 @@ describe('Field Reducer', () => {
 			}
 		};
 
-		const current_path = 'created';
+		const field_alias_path = 'created';
 
 		// Curry the field_reducer
-		const fr = field_reducer({current_path, table_schema, dareInstance});
+		const fr = field_reducer({field_alias_path, table_schema, dareInstance});
 
 		// Call the field with the
 		const f = ['created'].reduce(fr, []);
@@ -213,17 +220,26 @@ describe('Field Reducer', () => {
 			}
 		};
 
-		const current_path = 'created';
+		const field_alias_path = 'created';
 
 		// Curry the field_reducer
-		const fr = field_reducer({current_path, table_schema, dareInstance});
+		const fr = field_reducer({field_alias_path, table_schema, dareInstance});
+
 
 		// Call the field with the
 		const f = ['meta'].reduce(fr, []);
 
 		// Expect the formatted list of fields to be identical to the inputted value
 		expect(f[0])
-			.to.have.property('meta');
+			.to.equal('meta');
+
+		const [postProcessing] = dareInstance.generated_fields;
+
+		expect(postProcessing).to.be.a('object');
+
+		expect(postProcessing).to.have.property('label', 'meta');
+		expect(postProcessing).to.have.property('field_alias_path', field_alias_path);
+		expect(postProcessing).to.have.property('handler');
 
 	});
 
@@ -233,10 +249,10 @@ describe('Field Reducer', () => {
 			fieldAlias: 'field'
 		};
 
-		const current_path = 'joinTable.';
+		const field_alias_path = 'joinTable.';
 
 		// Curry the field_reducer
-		const fr = field_reducer({current_path, table_schema, dareInstance});
+		const fr = field_reducer({field_alias_path, table_schema, dareInstance});
 
 		// Call the field with the
 		const f = [{

--- a/test/specs/get-datatypes.js
+++ b/test/specs/get-datatypes.js
@@ -83,6 +83,42 @@ describe('get - datatypes', () => {
 
 		});
 
+		it('should JSON parse a nested field with object if type=json', async () => {
+
+			const meta = {param: 1};
+			const metaString = JSON.stringify(meta);
+
+			dare.execute = async ({sql, values}) => {
+
+				const expected = `
+					SELECT b.meta AS 'users.meta'
+					FROM users_email a
+					LEFT JOIN users b ON (b.id = a.user_id)
+					LIMIT 1
+				`;
+
+				sqlEqual(sql, expected);
+				expect(values).to.deep.equal([]);
+
+				return [{users: {meta: metaString}}];
+
+			};
+
+			const resp = await dare
+				.get({
+					table: 'users_email',
+					fields: [{
+						users: ['meta']
+					}]
+				});
+
+			expect(resp)
+				.to.have.property('users')
+				.to.have.property('meta')
+				.to.deep.equal(meta);
+
+		});
+
 		it('should return an empty object if response value is falsy', async () => {
 
 			dare.execute = async ({sql, values}) => {
@@ -114,5 +150,45 @@ describe('get - datatypes', () => {
 
 	});
 
-});
+	describe('type=function', () => {
 
+		it('should construct a generated function, which can be labelled', async () => {
+
+			const id = 123;
+
+			dare.execute = async ({sql, values}) => {
+
+				const expected = `
+					SELECT b.id AS 'users.id'
+					FROM users_email a
+					LEFT JOIN users b ON (b.id = a.user_id)
+					LIMIT 1
+				`;
+
+				sqlEqual(sql, expected);
+				expect(values).to.deep.equal([]);
+
+				return [{users: {id}}];
+
+			};
+
+			const resp = await dare
+				.get({
+					table: 'users_email',
+					fields: [{
+						users: [{
+							'URL': 'url'
+						}]
+					}]
+				});
+
+			expect(resp)
+				.to.have.property('users')
+				.to.have.property('URL', `/user/${id}`);
+
+
+		});
+
+	});
+
+});

--- a/test/specs/response_handler.js
+++ b/test/specs/response_handler.js
@@ -125,6 +125,80 @@ describe('response_handler', () => {
 
 	});
 
+	it('should transform a deep linked nested array with generated fields', () => {
+
+		const handler = row => row.id + 2;
+
+		// Create a list of generated fields
+		dare.generated_fields = [
+			{
+				label: 'generated',
+				field_alias_path: '',
+				handler
+			},
+			{
+				label: 'generated2',
+				field_alias_path: 'asset.',
+				handler
+			},
+			{
+				label: 'generated3',
+				field_alias_path: 'asset.collection.',
+				handler
+			},
+			{
+				label: 'generated4',
+				field_alias_path: 'asset.collection.assoc.',
+				handler
+			},
+			{
+				label: 'willnotappear',
+				field_alias_path: 'doesnotmatch.',
+				handler
+			}
+		];
+
+		const data = dare.response_handler([{
+			'field': 'value',
+			'id': 1,
+			'asset.id': 10,
+			'asset.collection[id,name,assoc.id,assoc.name]': '[["1","a","1a","aa"],["2","b","1b","ba"]]',
+			'asset.name': 'name'
+		}]);
+
+		expect(data).to.be.an('array');
+		expect(data[0]).to.deep.equal({
+			id: 1,
+			generated: 3,
+			field: 'value',
+			asset: {
+				id: 10,
+				generated2: 12,
+				name: 'name',
+				collection: [{
+					id: '1',
+					generated3: '12',
+					name: 'a',
+					assoc: {
+						id: '1a',
+						generated4: '1a2',
+						name: 'aa'
+					}
+				}, {
+					id: '2',
+					generated3: '22',
+					name: 'b',
+					assoc: {
+						id: '1b',
+						generated4: '1b2',
+						name: 'ba'
+					}
+				}]
+			}
+		});
+
+	});
+
 	it('should return empty value if it cannot be interpretted', () => {
 
 		/*
@@ -194,6 +268,7 @@ describe('response_handler', () => {
 
 
 });
+
 
 describe('response_row_handler', () => {
 


### PR DESCRIPTION
Dare didn't support deep nested generated fields more than a single depth, and then it also didn't work on arrays of items.

This PR fixes that and enables us to use generated fields in multiple places.