### PR TITLE
fix(orderby/groupby): Ensures these joins are not cropped from the query #152

### DIFF
--- a/src/format_request.js
+++ b/src/format_request.js
@@ -252,8 +252,8 @@ async function format_request(options = {}, dareInstance) {
 
 			// Help the GET parser
 
-			// Does this contain a nested filter?
-			join_object.has_filter = new_join_object.has_filter = !!join_object.filter;
+			// Does this contain a nested filter, orderby or groupby?
+			join_object.has_filter = new_join_object.has_filter = Boolean(join_object.filter || join_object.orderby || join_object.groupby);
 
 			// Does this contain nested fields
 			join_object.has_fields = new_join_object.has_fields = !!(Array.isArray(join_object.fields) ? join_object.fields.length : join_object.fields);

--- a/test/specs/get-sort-group.js
+++ b/test/specs/get-sort-group.js
@@ -96,6 +96,34 @@ const limit = 5;
 
 		});
 
+		it('should join on tables which do not return fields', async () => {
+
+			dare.sql = async sql => {
+
+				const expected = `
+					SELECT a.email
+					FROM users_email a
+					LEFT JOIN users b ON(b.id = a.user_id)
+					${SQL_EXPR} \`name\`
+					LIMIT 5
+				`;
+
+				expectSQLEqual(sql, expected);
+				return [{}];
+
+			};
+
+			return dare.get({
+				table: 'users_email',
+				fields: ['email'],
+				[prop]: [
+					'users.name'
+				],
+				limit
+			});
+
+		});
+
 	});
 
 });

--- a/test/specs/get-sort-group.js
+++ b/test/specs/get-sort-group.js
@@ -104,7 +104,7 @@ const limit = 5;
 					SELECT a.email
 					FROM users_email a
 					LEFT JOIN users b ON(b.id = a.user_id)
-					${SQL_EXPR} \`name\`
+					${SQL_EXPR} b.name
 					LIMIT 5
 				`;
 


### PR DESCRIPTION
Includes the orderby and groupby conditions, where previously they were omitted when they were not required as part of a fields or filter.