### PR TITLE
feat(alias): provide cross table field aliasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,27 @@ dare.get('users', ['emailAddress'], {emailAddress: 'andrew@%'});
 // SELECT email AS emailAddress FROM users WHERE email LIKE 'andrew@%'
 ```
 
+The aliasing can also be used for common functions and define fields on another table to abstract away some of the complexity in your relational schema and provide a cleaner api interface.
+
+e.g. 
+```js
+const dare = new Dare({
+	schema: {
+		users: {
+			emailAddress: {
+				// Explicitly define the alias
+				// Reference the email define on another table, we can also wrap in SQL functions.
+				alias: 'LOWER(usersEmails.email)'
+			}
+		},
+		// Any cross table join needs fields to map
+		usersEmails: {
+			user_id: ['users.id']
+		}
+	}
+});
+
+
 #### field readable/writeable
 
 A flag to control access to a field

--- a/test/specs/field_reducer.js
+++ b/test/specs/field_reducer.js
@@ -111,7 +111,28 @@ describe('Field Reducer', () => {
 				[{
 					'Field': 'asset.field'
 				}]
+			],
+			/*
+			 * Alias to another
+			 * Taps into an alias on the current model which maps to another table field
+			 */
+			[
+				['crossTableAlias'],
+				[],
+				[{
+					'crossTableAlias': 'b_table.realField'
+				}]
+			],
+			[
+				[{
+					'Field': 'COUNT(crossTableAlias)'
+				}],
+				[],
+				[{
+					'Field': 'COUNT(b_table.realField)'
+				}]
 			]
+
 
 		].forEach(test => {
 
@@ -121,7 +142,11 @@ describe('Field Reducer', () => {
 
 			// Details about the current table...
 			const field_alias_path = 'something.asset.';
-			const table_schema = {};
+			const table_schema = {
+				crossTableAlias: {
+					alias: 'b_table.realField'
+				}
+			};
 			const joined = {};
 			const extract = (key, value) => {
 


### PR DESCRIPTION
Extend the schema field aliasing to allow defining fields on another table.

This will remove some of the complexity in the relational schema and provide a cleaner api interface.

e.g. In this example the user emails are in another table. In order to provide a simple way to get the email from the users model by calling `emailAddress`, we can use the alias prop to map to the `userEmail.email` model.field where that value resides. This will automatically join on that table using the join key. And return the value with prop key `emailAddress`.

```js
const dare = new Dare({
	schema: {
		users: {
			emailAddress: {
				// Explicitly define the alias
				// Reference the email field on the usersEmails table.
				// Plus: wrap in SQL formatting if so inclined.
				alias: 'LOWER(usersEmails.email)'
			}
		},
		// Any cross table join needs fields to map
		usersEmails: {
			user_id: ['users.id']
		}
	}
});
