### PR TITLE
feat: allow overriding the schema per operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,3 +902,37 @@ const data = await dare.get('users', ['name'], {limit: 10000000});
 
 console.log(data.length === 0); // empty array
 ```
+
+
+### Overriding table schema per operation
+
+You can override the schema per operation using the `schema` option:
+
+E.g.
+
+```js
+const dare = new Dare({
+  schema: {
+    my_table: {
+      write_protected_field: {
+        type: 'datetime',
+        writeable: false,
+      },
+    },
+  }
+});
+
+await dare.patch({
+  table: 'my_table',
+  body: {
+    write_protected_field: 'new value,
+  },
+  schema: {
+    my_table: {
+      write_protected_field: {
+        writeable: true,
+      },
+    },
+  },
+});
+```

--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,7 @@ Dare.prototype.patch = async function patch(table, filter, body, opts = {}) {
 	validateBody(req.body);
 
 	// Get the schema
-	const tableSchema = this.options.schema && this.options.schema[req.table];
+	const tableSchema = _this.options.schema && _this.options.schema[req.table];
 
 	// Prepare post
 	const {assignments, preparedValues} = prepareSet(req.body, tableSchema);
@@ -376,7 +376,7 @@ Dare.prototype.post = async function post(table, body, opts = {}) {
 	}
 
 	// Get the schema
-	const tableSchema = this.options.schema && this.options.schema[req.table];
+	const tableSchema = _this.options.schema && _this.options.schema[req.table];
 
 	// Capture keys
 	const fields = [];

--- a/test/specs/schema_override.js
+++ b/test/specs/schema_override.js
@@ -1,0 +1,91 @@
+describe('schema override', () => {
+
+	let dare;
+
+	beforeEach(() => {
+
+		dare = new Dare({
+			schema: {
+				users: {
+					write_protected_field: {
+						writeable: false
+					}
+				}
+			}
+		});
+
+		dare.execute = async () => ({ // Run SQL query ...
+			success: true
+		});
+
+	});
+
+	describe('patch', () => {
+
+		it('allows overriding the schema of patch operations', async () => {
+
+			const patchOptions = {
+				table: 'users',
+				filter: {
+					id: 1234
+				},
+				body: {
+					write_protected_field: 'new value'
+				}
+			};
+
+			const callBeforeOverride = dare.patch(patchOptions);
+
+			await expect(callBeforeOverride).to.be.eventually.rejected;
+
+			const callAfterOverride = dare.patch({
+				...patchOptions,
+				schema: {
+					users: {
+						write_protected_field: {
+							writeable: true
+						}
+					}
+				}
+			});
+
+			await expect(callAfterOverride).to.be.eventually.fulfilled;
+
+		});
+
+	});
+
+	describe('post', () => {
+
+		it('allows overriding the schema of post operations', async () => {
+
+			const postOptions = {
+				table: 'users',
+				body: {
+					id: 1234,
+					write_protected_field: 'new value'
+				}
+			};
+
+			const callBeforeOverride = dare.post(postOptions);
+
+			await expect(callBeforeOverride).to.be.eventually.rejected;
+
+			const callAfterOverride = dare.post({
+				...postOptions,
+				schema: {
+					users: {
+						write_protected_field: {
+							writeable: true
+						}
+					}
+				}
+			});
+
+			await expect(callAfterOverride).to.be.eventually.fulfilled;
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
Allow overriding the schema of the table we are overriding using `dare.post` and `dare.patch`.