### PR TITLE
feat: ignore suffix on field property

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ The type of value affects the choice of SQL Condition syntax to use. For example
 | name    | 'Andrew'                  | string         | `name = 'Andrew'`
 | name    | 'And%'                    | Pattern        | `name LIKE 'And%'`
 | -name   | 'And%'                    | Pattern        | `name NOT LIKE 'And%'`
+| name$1  | any                  	  | any            | e.g. `name LIKE '%And%` $suffixing gives `name` alternative unique object key values, useful when writing `name LIKE %X% AND name LIKE %Y%`
 | tag     | [1, 'a']                  | Array values   | `tag IN (1, 'a')`
 | -tag    | [1, 'a']                  | Array values   | `tag NOT IN (1, 'a')`
 | -status | ['deleted', null]         | Array values   | `(status NOT IN ('deleted') AND status IS NOT NULL)` Mixed type including `null`

--- a/src/format/field_reducer.js
+++ b/src/format/field_reducer.js
@@ -1,6 +1,6 @@
 const checkFormat = require('../utils/unwrap_field');
 const checkLabel = require('../utils/validate_label');
-const checkKey = require('../utils//validate_field');
+const checkKey = require('../utils/validate_field');
 const DareError = require('../utils//error');
 const fieldRelativePath = require('../utils/field_relative');
 const getFieldAttributes = require('../utils/field_attributes');
@@ -67,7 +67,7 @@ module.exports = function fieldReducer({field_alias_path, extract, table_schema,
 		else {
 
 			// Check errors in the key field
-			checkKey(field);
+			field = checkKey(field);
 
 			const formattedField = fieldMapping({field, table_schema, fieldsArray, field_alias_path, originalArray, dareInstance, extract});
 

--- a/src/format/reducer_conditions.js
+++ b/src/format/reducer_conditions.js
@@ -54,8 +54,8 @@ module.exports = function reduceConditions(filter, {extract, propName, table_sch
 		}
 		else {
 
-			// Check this is a path
-			checkKey(key);
+			// Format key and validate path
+			key = checkKey(key);
 
 			const key_definition = table_schema[key];
 			filterArr.push(prepCondition(key, value, key_definition, negate));

--- a/src/utils/validate_field.js
+++ b/src/utils/validate_field.js
@@ -4,7 +4,11 @@ const validate_alias = require('./validate_alias');
 module.exports = function validate_field(key) {
 
 	const a = key.split('.');
-	const field = a.pop();
+
+	const field = a
+		.pop()
+		// Remove any alias suffix from the key
+		.replace(/\$.*$/, '');
 
 	const reg = /^([a-z_]+)$/i;
 
@@ -16,12 +20,15 @@ module.exports = function validate_field(key) {
 	}
 
 	// Validate the path
-	const path = a.join('.');
 
-	if (path) {
+	if (a.length) {
+
+		const path = a.join('.');
 
 		validate_alias(path);
 
 	}
+
+	return [...a, field].join('.');
 
 };

--- a/test/specs/field_reducer.js
+++ b/test/specs/field_reducer.js
@@ -131,6 +131,12 @@ describe('Field Reducer', () => {
 				[{
 					'Field': 'COUNT(b_table.realField)'
 				}]
+			],
+
+			// Should ignore trailing $suffix
+			[
+				['field$suffix'],
+				['field']
 			]
 
 

--- a/test/specs/format_request.js
+++ b/test/specs/format_request.js
@@ -570,6 +570,13 @@ describe('format_request', () => {
 						'date',
 						'(NOT $$ > ? OR $$ IS NULL)',
 						['1981-12-05T00:00:00']
+					],
+					[
+						// Should ignore $ (suffixing) keys
+						{'prop$asdasd': null},
+						'prop',
+						'IS NULL',
+						[]
 					]
 				];
 

--- a/test/specs/get.js
+++ b/test/specs/get.js
@@ -148,6 +148,26 @@ describe('get', () => {
 
 		});
 
+		it('should ignore $suffixing', async () => {
+
+			const name = 'And%';
+			const name$and = '%drew';
+			dare.execute = async ({sql, values}) => {
+
+				sqlEqual(sql, 'SELECT a.id, a.name, a.prop FROM test a WHERE a.name LIKE ? AND a.name LIKE ? LIMIT 5');
+				expect(values).to.deep.equal([name, name$and]);
+
+				return [basic_record, basic_record];
+
+			};
+
+			const resp = await dare
+				.get('test', basic_fields.concat(['prop$ignore']), {name, name$and}, {limit: 5});
+
+			expect(resp).to.be.a('array');
+
+		});
+
 		it('should have an overidable limit', async () => {
 
 			dare.execute = async ({sql, values}) => {


### PR DESCRIPTION
Allows multiple **AND** conditions on the same key prop. 

e.g.  To create a search for a name where order is arbitrary, we need a query like `name LIKE '%Andrew%' AND name LIKE '%Dodson%'`. This was not possible before since object keys have to be unique.

note: Workaround were possible using aliasing fields, but that would change the schema and is non-scalable.

With suffixing (which is already used in tablenames) it is possible to make an field and filter key prop with an alternative value, So additional conditions can be added agains the same key.

e.g: Search for Strings in a _name_ field, when we're not sure of the order they occur...

```js
dare.get({
   table: 'users',
   fields: ['name'],
   filter: {
       name: '%Andrew%',
       name$also: '%Dodson%',
   }
});

// SELECT name FROM users WHERE name LIKE '%Andrew%' AND name LIKE '%Dodson%'
```

