### PR TITLE
fix(subquery): fix null subquery response

### DIFF
--- a/src/response_handler.js
+++ b/src/response_handler.js
@@ -74,11 +74,19 @@ function formatHandler(item) {
 			// Lets split the value up
 			value = JSONparse(value);
 
-			label.split(',').forEach((label, index) => {
+			/*
+			 * Ensure this is an Array
+			 * Subqueries may return NULL if they do not match any records
+			 */
+			if (Array.isArray(value)) {
 
-				explodeKeyValue(item, label.split('.'), value[index]);
+				label.split(',').forEach((label, index) => {
 
-			});
+					explodeKeyValue(item, label.split('.'), value[index]);
+
+				});
+
+			}
 
 		}
 

--- a/test/integration/data/schema.sql
+++ b/test/integration/data/schema.sql
@@ -1,9 +1,33 @@
 CREATE TABLE `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL,
+  `username` varchar(255) NOT NULL,
   `first_name` varchar(255) DEFAULT NULL,
   `last_name` varchar(255) DEFAULT NULL,
   `secret` varchar(2048) DEFAULT NULL,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `uind` (`username`)
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
+
+CREATE TABLE `teams` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `description` TEXT NULL,
+  PRIMARY KEY (`id`),
   UNIQUE KEY `uind` (`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
+
+CREATE TABLE `userTeams` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `team_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+
+	-- users
+	KEY `fk_userTeams_user_id` (`user_id`),
+  CONSTRAINT `fk_userTeams_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+
+  -- teams
+	KEY `fk_userTeams_team_id` (`team_id`),
+  CONSTRAINT `fk_userTeams_team_id` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`)
+
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;

--- a/test/integration/get.spec.js
+++ b/test/integration/get.spec.js
@@ -1,5 +1,15 @@
 const Dare = require('../../src');
+// DEBUG const mysql = require('mysql2/promise');
+
 const {db} = global;
+const schema = {
+	teams: {},
+	users: {},
+	userTeams: {
+		'user_id': ['users.id'],
+		'team_id': ['teams.id']
+	}
+};
 
 // Connect to db
 
@@ -10,34 +20,137 @@ describe('dare init tests', () => {
 	beforeEach(() => {
 
 		// Initiate
-		dare = new Dare();
+		dare = new Dare({schema});
 
 		// Set a test instance
-		dare.execute = query => db.query(query);
+		// eslint-disable-next-line arrow-body-style
+		dare.execute = query => {
+
+			// DEBUG console.log(mysql.format(query.sql, query.values));
+
+			return db.query(query);
+
+		};
 
 	});
 
 	it('Can insert and retrieve results ', async () => {
 
-		const name = 'A Name';
-		await dare.post('users', {name});
+		const username = 'A Name';
+		await dare.post('users', {username});
 
-		const resp = await dare.get('users', ['name']);
+		const resp = await dare.get('users', ['username']);
 
-		expect(resp).to.have.property('name', name);
+		expect(resp).to.have.property('username', username);
 
 	});
 
 	it('Can update results', async () => {
 
-		const name = 'A Name';
+		const username = 'A Name';
 		const newName = 'New name';
-		const {insertId} = await dare.post('users', {name});
-		await dare.patch('users', {id: insertId}, {name: newName});
+		const {insertId} = await dare.post('users', {username});
+		await dare.patch('users', {id: insertId}, {username: newName});
 
-		const resp = await dare.get('users', ['name']);
+		const resp = await dare.get('users', ['username']);
 
-		expect(resp).to.have.property('name', newName);
+		expect(resp).to.have.property('username', newName);
+
+	});
+
+
+	it('should be able to return nested values', async () => {
+
+		const teamName = 'A Team';
+
+		// Create users, team and add the two
+		const [user, team] = await Promise.all([
+
+			// Create user
+			dare.post('users', {username: 'user123'}),
+
+			// Create team
+			dare.post('teams', {name: teamName})
+
+		]);
+
+		// Add to the pivot table
+		await dare.post('userTeams', {user_id: user.insertId, team_id: team.insertId});
+
+
+		{
+
+			// Same Structure
+			const resp = await dare.get({
+				table: 'users',
+				fields: [
+					{
+						'userTeams': {
+							'teams': [
+								'id',
+								'name',
+								'description'
+							]
+						}
+					}
+				]
+			});
+
+			expect(resp)
+				.to.deep.nested.include({'userTeams[0].teams': {
+					id: String(team.insertId),
+					name: teamName,
+					description: ''
+				}});
+
+		}
+
+		{
+
+			// Remap Structure
+			const resp = await dare.get({
+				table: 'users',
+				fields: [
+					{
+						'id': 'userTeams.teams.id',
+						'name': 'userTeams.teams.name',
+						'description': 'userTeams.teams.description'
+					}
+				]
+			});
+
+			expect(resp)
+				.to.deep.nested.equal({
+					id: String(team.insertId),
+					name: teamName,
+					description: ''
+				});
+
+		}
+
+
+		{
+
+			// Remap Structure
+			const resp = await dare.get({
+				table: 'users',
+				fields: [
+					{
+						'id': 'userTeams.teams.id',
+						'name': 'userTeams.teams.name',
+						'description': 'userTeams.teams.description'
+					}
+				],
+				join: {
+					// When there are no results we get an empty value
+					userTeams: {id: -1}
+				}
+			});
+
+			expect(resp)
+				.to.deep.nested.equal({});
+
+		}
 
 	});
 

--- a/test/specs/response_handler.js
+++ b/test/specs/response_handler.js
@@ -45,7 +45,8 @@ describe('response_handler', () => {
 		const data = dare.response_handler([{
 			'field': 'value',
 			'assoc.id,assoc.name': '["1","a"]',
-			'a,b': Buffer.from('["1","2"]')
+			'a,b': Buffer.from('["1","2"]'),
+			'ignore,null': null
 		}]);
 
 		expect(data).to.be.an('array');
@@ -60,6 +61,7 @@ describe('response_handler', () => {
 		});
 
 	});
+
 
 	it('should given a nested dataset', () => {
 


### PR DESCRIPTION
Fixes bug which looks like 

```
  1) response_handler
       should given a field with an array of fields in the title split the values:
     TypeError: Cannot read property '0' of undefined
      at /Users/andrewdodson/workspace/dare/src/response_handler.js:18:182
      at Array.forEach (<anonymous>)
      at formatHandler (src/response_handler.js:18:66)
      at /Users/andrewdodson/workspace/dare/src/response_handler.js:5:35
      at Array.reduce (<anonymous>)

```

Although the line numbers are off, should read `at formatHandler (src/response_handler.js:79:21)`