### PR TITLE
fix(suffixing): model names with $ in nested fields handling

### DIFF
--- a/src/response_handler.js
+++ b/src/response_handler.js
@@ -93,7 +93,7 @@ function formatHandler(item) {
 		else {
 
 			// This has multiple parts
-			const r = /^([a-z0-9.\s_-]*)\[(.*?)\]$/i;
+			const r = /^([a-z0-9.$\s_-]*)\[(.*?)\]$/i;
 			const m = label.match(r);
 
 			if (!m) {

--- a/test/specs/response_handler.js
+++ b/test/specs/response_handler.js
@@ -98,6 +98,7 @@ describe('response_handler', () => {
 			'field': 'value',
 			'asset.id': 1,
 			'asset.collection[id,name,assoc.id,assoc.name]': '[["1","a","a1","aa"],["2","b","b1","ba"]]',
+			'asset$planb.collection[id,name]': '[["1","a"],["2","b"]]',
 			'asset.name': 'name'
 		}]);
 
@@ -121,6 +122,15 @@ describe('response_handler', () => {
 						id: 'b1',
 						name: 'ba'
 					}
+				}]
+			},
+			'asset$planb': {
+				collection: [{
+					id: '1',
+					name: 'a'
+				}, {
+					id: '2',
+					name: 'b'
 				}]
 			}
 		});


### PR DESCRIPTION
Allows nested response objects to be defined with the suffixing marker `$`, 

i.e. Prior to this the model names with a `...$[suffix]` would have not have had their values expanded as expected

```diff
AssertionError: expected { Object (field, asset$planb.collection[id,name], ...) } to deeply equal { Object (field, asset, ...) }
+ expected
- actual

     ]
     "id": 1
     "name": "name"
   }
-  "asset$planb.collection[id,name]": "[[\"1\",\"a\"],[\"2\",\"b\"]]"
+  "asset$planb": {
+    "collection": [
+      {
+        "id": "1"
+        "name": "a"
+      }
+      {
+        "id": "2"
+        "name": "b"
+      }
+    ]
+  }
   "field": "value"
 }
```