### PR TITLE
fix(generated): fix referencing a nested generated field

### DIFF
--- a/src/format/field_reducer.js
+++ b/src/format/field_reducer.js
@@ -183,6 +183,7 @@ function fieldMapping({field, label, fieldsArray, originalArray, field_alias_pat
 			// Add for post processing
 			dareInstance.generated_fields.unshift({
 				label,
+				field,
 				field_alias_path,
 				handler: generated_field,
 				extraFields
@@ -192,7 +193,10 @@ function fieldMapping({field, label, fieldsArray, originalArray, field_alias_pat
 
 		}
 
-		// Execute the handler, add the response to the field list
+		/**
+		 * Otherwise the generated field has returned a string
+		 * Return the string
+		 */
 		return {
 			[label]: generated_field
 		};
@@ -227,6 +231,7 @@ function fieldMapping({field, label, fieldsArray, originalArray, field_alias_pat
 		// Add for post processing
 		dareInstance.generated_fields.push({
 			label,
+			field,
 			field_alias_path,
 			handler: item => jsonParse(item[label]) || {}
 		});

--- a/src/response_handler.js
+++ b/src/response_handler.js
@@ -7,6 +7,17 @@ module.exports = function responseHandler(resp) {
 
 	const dareInstance = this;
 
+	// Format generated_fields
+
+	this.generated_fields.forEach(obj => {
+
+		// Extend with preformatted target address...
+		obj.targetAddress = getTargetPath(obj.field_alias_path, obj.field)
+			.split('.')
+			.filter(Boolean);
+
+	});
+
 	// Iterate over the response array and trigger formatting
 	return resp.reduce((items, row, index) => {
 
@@ -17,11 +28,8 @@ module.exports = function responseHandler(resp) {
 
 		this.generated_fields.forEach(obj => {
 
-			// Split the address of the item up...
-			const address = obj.field_alias_path.split('.').filter(Boolean);
-
 			// Generate the fields handler
-			generatedFieldsHandler({...obj, address, item}, dareInstance);
+			generatedFieldsHandler({...obj, target: item}, dareInstance);
 
 		});
 
@@ -192,27 +200,126 @@ function explodeKeyValue(obj, a, value) {
  * Generate Fields Handler
  * @param {object} obj - Request Object
  * @param {string} obj.label - Name of the property to be created
+ * @param {string} obj.field - Name of the property to be created
  * @param {Function} obj.handler - Function to process the request
- * @param {Array} obj.address - Paths of the item
- * @param {obj} obj.item - Obj where the new prop will be appended
+ * @param {Array} obj.targetAddress - Paths of the target item
+ * @param {obj} obj.target - Obj where the new prop will be appended
  * @param {obj} obj.extraFields - List of fields which can be removed from the response
  * @param {obj} dareInstance - Dare Instance
  * @returns {void} Modifies the incoming request with new props
  */
-function generatedFieldsHandler({label, handler, address, item, extraFields = []}, dareInstance) {
+function generatedFieldsHandler({label, field, handler, targetAddress, target, extraFields = []}, dareInstance) {
+
+
+	if (targetAddress.length === 0) {
+
+		// Get the handler props
+		const props = getHandlerPropsByAddress(field, target, extraFields);
+
+		// Get the item
+		target[label] = handler.call(dareInstance, props);
+
+		return;
+
+	}
+
+	// Get the current position in the address
+	const [modelname] = targetAddress;
+
+	// Shift the item off the address, creating a new address
+	const next_address = targetAddress.slice(1);
+
+	// Get the nested object
+	const nested = target[modelname];
+
+	// Assuming it's a valid resource...
+	if (nested) {
+
+		// And treat single and array items the same for simplicity
+		(Array.isArray(nested) ? nested : [nested])
+			.forEach(target => {
+
+				generatedFieldsHandler({
+					targetAddress: next_address,
+					target,
+					label,
+					field,
+					handler,
+					extraFields
+				}, dareInstance);
+
+			});
+
+	}
+
+}
+
+
+/**
+ * Get target path
+ * Given a model path, such as `picture`, reduce it of the parent path in the request path like `picture.url`
+ * So the result would be empty path because the target is on the base.
+ * If model path is `picture` and the request path is `url`, then the target path is just `picture`
+ * @param {string} modelPath - Model Path
+ * @param {string} requestPath - Request Path (incl. field)
+ * @returns {string} Target path
+ */
+function getTargetPath(modelPath, requestPath) {
+
+	// Remove the field from the request Path
+	const requestModelPath = requestPath.slice(0, requestPath.lastIndexOf('.') + 1);
+
+	// Remove the requestModelPath from the modelPath
+	return modelPath.replace(new RegExp(`${requestModelPath}$`), '');
+
+}
+
+
+/**
+ * GetHandlerPropsByAddress
+ *
+ * @param {string} requestPath - String denoting the path of the props
+ * @param {object} item - Item with the nested props
+ * @param {Array} extraFields - extrafields which can be removed afterwards
+ * @returns {object} Props object
+ */
+function getHandlerPropsByAddress(requestPath, item, extraFields) {
+
+	// Remove the field from the request Path
+	const requestModelAddress = requestPath
+		.slice(0, requestPath.lastIndexOf('.') + 1)
+		.split('.')
+		.filter(Boolean);
+
+
+	// Get the nested object
+	const [props] = getNestedObject(item, requestModelAddress);
+
+	// Clone the props...
+	const handler_props = {...props};
+
+
+	// End early is there is no results
+	if (props) {
+
+		// Remove attributes from the props
+		extraFields.forEach(key => delete props[key]);
+
+	}
+
+	// Walk the object and remove empty objects...
+	removeEmptyObject(item, requestModelAddress);
+
+	return handler_props;
+
+}
+
+function getNestedObject(obj, address, arr = []) {
 
 	if (address.length === 0) {
 
-		item[label] = handler.call(dareInstance, item);
-
-		// Remove the extra fields
-		extraFields.forEach(field => {
-
-			delete item[field];
-
-		});
-
-		return;
+		arr.push(obj);
+		return arr;
 
 	}
 
@@ -223,15 +330,63 @@ function generatedFieldsHandler({label, handler, address, item, extraFields = []
 	const next_address = address.slice(1);
 
 	// Get the nested object
-	const nested = item[modelname];
+	const nested = obj[modelname];
 
 	// Assuming it's a valid resource...
 	if (nested) {
 
 		// And treat single and array items the same for simplicity
 		(Array.isArray(nested) ? nested : [nested])
-			.forEach(item => generatedFieldsHandler({label, handler, extraFields, address: next_address, item}, dareInstance));
+			.forEach(next_obj => getNestedObject(next_obj, next_address, arr));
 
 	}
+
+	return arr;
+
+}
+
+
+function removeEmptyObject(obj, address) {
+
+	if (address.length === 0) {
+
+		return Object.keys(obj).length === 0;
+
+	}
+
+	// Get the current position in the address
+	const [modelname] = address;
+
+	// Shift the item off the address, creating a new address
+	const next_address = address.slice(1);
+
+	// Get the nested object
+	const nested = obj[modelname];
+
+	// Assuming it's a valid resource...
+	if (nested) {
+
+		if (Array.isArray(nested)) {
+
+			// Find and remove empties from the array...
+			obj[modelname] = nested.filter(next_obj => !removeEmptyObject(next_obj, next_address));
+
+			if (obj[modelname].length === 0) {
+
+				delete obj[modelname];
+
+			}
+
+		}
+
+		if (removeEmptyObject(nested, next_address)) {
+
+			delete obj[modelname];
+
+		}
+
+	}
+
+	return false;
 
 }

--- a/test/specs/get-join.js
+++ b/test/specs/get-join.js
@@ -670,7 +670,7 @@ describe('get - request object', () => {
 
 		});
 
-		it.skip('should allow generated fields to be rendered in the response', async () => {
+		it('should allow generated fields to be restructured in the reponse', async () => {
 
 			// Stub the execute function
 			dare.sql = () =>
@@ -700,8 +700,6 @@ describe('get - request object', () => {
 			expect(resp).to.deep.equal({
 				name: 'Andrew',
 				thumbnail: '/asset/1/thumbnail',
-				picture: {
-				},
 				pictureUrl: 'http://example.com/picture/100/image'
 			});
 

--- a/test/specs/response_handler.js
+++ b/test/specs/response_handler.js
@@ -140,6 +140,7 @@ describe('response_handler', () => {
 	it('should transform a deep linked nested array with generated fields', () => {
 
 		const handler = row => row.id + 2;
+		const field = 'something';
 
 		const extraFields = ['id'];
 
@@ -147,30 +148,35 @@ describe('response_handler', () => {
 		dare.generated_fields = [
 			{
 				label: 'generated',
+				field,
 				field_alias_path: '',
 				handler,
 				extraFields
 			},
 			{
 				label: 'generated2',
+				field,
 				field_alias_path: 'asset.',
 				handler,
 				extraFields
 			},
 			{
 				label: 'generated3',
+				field,
 				field_alias_path: 'asset.collection.',
 				handler,
 				extraFields: []
 			},
 			{
 				label: 'generated4',
+				field,
 				field_alias_path: 'asset.collection.assoc.',
 				handler,
 				extraFields
 			},
 			{
 				label: 'willnotappear',
+				field,
 				field_alias_path: 'doesnotmatch.',
 				handler,
 				extraFields
@@ -210,6 +216,76 @@ describe('response_handler', () => {
 					}
 				}]
 			}
+		});
+
+	});
+
+	it('should transform a nested arrays to single root level', () => {
+
+		const empty = 'empty';
+		const handler = row => (row.id ? row.id + 2 : empty);
+
+		const extraFields = ['id', 'name'];
+
+		// Create a list of generated fields
+		dare.generated_fields = [
+			{
+				label: 'LabelA',
+				field: 'a.id',
+				field_alias_path: '',
+				handler,
+				extraFields
+			},
+			{
+				label: 'LabelB',
+				field: 'b.id',
+				field_alias_path: '',
+				handler,
+				extraFields
+			},
+			{
+				label: 'LabelC',
+				field: 'c.id',
+				field_alias_path: '',
+				handler,
+				extraFields
+			},
+			{
+				label: 'LabelD',
+				field: 'd.id',
+				field_alias_path: '',
+				handler,
+				extraFields
+			},
+			{
+				label: 'LabelE',
+				field: 'e.id',
+				field_alias_path: '',
+				handler,
+				extraFields
+			}
+		];
+
+		const data = dare.response_handler([{
+			'a[id,name]': '[["1","a"]]',
+			'b[id,name]': '[["1","a"],["2","b"]]',
+			'c[id,name]': '[]',
+			'd[id,name]': '[[]]',
+			'e[id,name]': null
+		}]);
+
+		expect(data).to.be.an('array');
+		expect(data[0]).to.deep.equal({
+			// @todo remove this b prop.
+			b: [{
+				id: '2',
+				name: 'b'
+			}],
+			LabelA: '12',
+			LabelB: '12',
+			LabelC: empty,
+			LabelD: empty,
+			LabelE: empty
 		});
 
 	});


### PR DESCRIPTION
Reenables a skipped test which allows us to reference nested generated field, e.g.

```
fields: {
    "My Picture": "a_joined_model.a_gen_field"
}
```

Previously this would ignore the labelling and create an object. This PR resolves that.

TODO: Tidy this up an improve performance by moving some of the interpretation outside of the loop.