### PR TITLE
feat(models): support for new options.models structure

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [12, 14, 16]
+        node_version: [14, 16]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -603,6 +603,17 @@ const myModel = {
 }
 ```
 
+
+## Model Table `table`
+
+The underlying Database SQL Table to use when querying this model, if omitted Dare will assume the models label instead
+
+```js
+const myModel = {
+	table: 't_mytable' // an example table name: some dba's do like to prefix table names, however it's not a convention which makes for a nice api.
+	// ...
+}
+```
 ## Model Schema `schema`
 
 The `schema` property defines an object, containing field attribute references in key=>value pair, i.e. `fieldName (key) => field attributes (value)`.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 
 
 
-Dare is a lovely API for generating SQL out of structured JS Object. It can be used to query and modify your flavour of SQL database inside your node app. Or if you dare, give it it's own restful interface and have it construct and execute all the scrumptuous queries the client throws at it. Now the security conscious amongst you may fret but dont fear, your own rules can be applied via "handlers" by table and method, just the thing for maintaining data integrity and developing REST interfaces.
-
+Dare is a lovely API for generating SQL out of structured Javascript object. It's more than just sugar to querying a SQL database though, as you will discover.
 # Example usage...
 
 This is a simple setup to get started with, it'll make a basic SELECT query.
@@ -24,7 +23,7 @@ const sqlConn = require('./mySqlConn');
 const dare = new Dare();
 
 // Define the handler dare.execute for handing database requests
-dare.execute = async ({sql, values}) => {
+await dare.execute = async ({sql, values}) => {
 	// Execute query using prepared statements
 	return sqlConn.execute(sql, values);
 };
@@ -36,252 +35,11 @@ const resp = await dare.get('users', ['name'], {id: 1});
 console.log(`Hi ${resp.name}');
 ```
 
-
-# Setup
-
-
 ## Install
 
 ```bash
 npm i dare --save
 ```
-
-
-## dare = new Dare(options)
-
-Create an instance of Dare with some options
-
-```js
-const Dare = require('dare');
-
-const options = {
-	schema
-};
-
-const dare = new Dare(options);
-```
-
-## Options
-
-The `options Object` is a set of properties to apply at the point of calling any methods. Initially it's used to define default properties. However every method creates its own instance inheritting its parent options as well as defining it's own. See `dare.use(options)` for more.
-
-The `options` themselves are a set of properties used to interpret and manipulate the request.
-
-
-## Schema `schema`
-
-The schema is used to define the structure of your SQL database. You can refer to it as `options.schema`. It's each property in the schema pertains to a database table. And defines the fields within the table.
-
-e.g.
-
-```js
-const dare = new Dare({
-	schema: {
-		users: {
-			// user field defitions
-		},
-		country: {
-			// country field defitions
-		}
-	}
-});
-```
-
-### Relationships
-
-In the example below the fields `users.country_id` defines a relationship with `country.id` which is used to construct SQL JOIN Conditions.
-
-
-```js
-const dare = new Dare({
-	schema : {
-		users: {
-			// users fields...
-			country_id: 'country.id'
-		},
-		country: {
-			// country fields...
-		}
-	}
-});
-```
-
-### Field Definition
-
-Fields dont need to be explicitly defined in the `options.schema.*tbl*`. Fields which are defined can give hints as to how to handle them.
-
-#### field reference
-
-Fields can reference other table fields, this is used to construct relationships [as we've seen earlier](#relationships).
-
-
-#### field type
-
-Defining the `type` introduces additional features.
-
-**`datatime`**
-
-Setting value to 'datetime', a conditional filter short hand for `created_time: 2017` would be expanded to `created_time BETWEEN '2017-01-01T00:00:00' AND '2017-12-31T23:59:59`
-
-```js
-const dare = new Dare({
-	schema: {
-		users: {
-			created_time: {
-				type: 'datetime'
-			}
-		}
-	}
-});
-```
-
-**`json`**
-
-Serializes Objects and Deserializes JSON strings in `get`, `post` and `patch` operations.
-
-e.g.
-
-Schema: field definition...
-```js
-const dare = new Dare({
-	schema: {
-		users: {
-			meta: {
-				// Define a field meta with data type of json
-				type: 'json'
-			}
-		}
-	}
-});
-```
-
-Example set and get
-```js
-	// Arbitary object...
-	const meta = {
-		prop1: 1,
-		prop2: 2
-	};
-
-	// For a field named `meta`
-	const {insertId: id} = await dare.post('users', {meta});
-	// The value is run through JSON.stringify before insertion
-	// INSERT INOT users (meta) VALUES('{"prop1": 1, "prop2": 2}')
-
-
-	...
-
-	// The value is desiralized, when accessed via get...
-	const {meta} = await dare.get('users', ['meta'], {id});
-
-	// e.g...
-	console.log(meta);
-	// Object({
-	// 	prop1: 1,
-	// 	prop2: 2
-	// });
-
-```
-
-
-#### field handler
-
-When the value is a function, the function will be invoked when interpretting the request as part of a field value. The response of this function can either be a static value or it can be an additional function which is optionally run on all items in the response, to return a generated field.
-
-E.g.
-
-This will manipulate the request and response to create the property `avatar_url` on the fly.
-
-```js
-const dare = new Dare({
-	schema: {
-		users: {
-			avatar_url(fields) {
-
-				fields.push('id'); // require additional field from users table.
-
-				return (item) => `/images/avatars/${item.id}`;
-			}
-		}
-	}
-});
-```
-
-#### field alias
-
-To alias a field, so that you can use a name different to the db column name, assign it a string name of the field in the current table. e.g. `emailAddress: 'email'`
-
-
-```js
-const dare = new Dare({
-	schema: {
-		users: {
-			emailAddress: 'email'
-		}
-	}
-});
-```
-
-For example this will allow us to use the alias `emailAddress` in our api (see below), but the SQL generated will refer to it with it's true field name "`email`".
-
-```js
-dare.get('users', ['emailAddress'], {emailAddress: 'andrew@%'});
-// SELECT email AS emailAddress FROM users WHERE email LIKE 'andrew@%'
-```
-
-The aliasing can also be used for common functions and define fields on another table to abstract away some of the complexity in your relational schema and provide a cleaner api interface.
-
-e.g. 
-```js
-const dare = new Dare({
-	schema: {
-		users: {
-			emailAddress: {
-				// Explicitly define the alias
-				// Reference the email define on another table, we can also wrap in SQL functions.
-				alias: 'LOWER(usersEmails.email)'
-			}
-		},
-		// Any cross table join needs fields to map
-		usersEmails: {
-			user_id: ['users.id']
-		}
-	}
-});
-
-
-#### field readable/writeable
-
-A flag to control access to a field
-
-```js
-const dare = new Dare({
-	schema: {
-		users: {
-			id: {
-				writeable: false // non-writeable
-			},
-			password: false // non-readable + non-writeable
-		}
-	}
-})
-```
-
-With the above `writeable`/`readable` field definitions an error is thrown whenever attempting to access the field e.g.
-
-```js
-dare.get('users', ['password'], {id: 123});
-// throws {code: INVALID_REFERENCE}
-```
-
-Or when trying to modify a field through `post` or `patch` methods, e.g.
-
-```js
-dare.patch('users', {id: 321}, {id: 1337});
-// throws {code: INVALID_REFERENCE}
-```
-
-
 
 # Methods
 
@@ -299,18 +57,18 @@ The `dare.get` method is used to build and execute a `SELECT ...` SQL statement.
 e.g.
 
 ```js
-dare.get('table', ['name'], {id: 1});
+await dare.get('table', ['name'], {id: 1});
 // SELECT name FROM table WHERE id = 1 LIMIT 1;
 ```
 
 ## dare.get(options Object)
 
-Alternatively a options Object can be used instead.
+Alternatively an options Object can be used instead.
 
 e.g.
 
 ```js
-dare.get({
+await dare.get({
 	table: 'users',
 	fields: ['name'],
 	filter: {
@@ -321,41 +79,70 @@ dare.get({
 
 ### Fields Array `fields`
 
-The fields array is defined in `dare.get(...[,fields]...)` only and says what fields from the matching resultset to return.
+The `fields` property is the second argument in the shorthand request `dare.get(table,fields[], ...)`. It is an Array of the fields from the matching table to return.
 
-#### Items (strings)
+In its simplest form `fields` it is an Array of Strings, e.g. `['id', 'name', 'created_date']`. This creates a very simple query.
 
-In its simplest form it is an Array of Strings, e.g. `['id', 'name', 'created_date']`. This creates a very simple query.
-
-```sql
-SELECT id, name, created_date FROM ....
+```js
+await dare.get('users', ['id', 'name', 'created_date'], ...);
+// SELECT id, name, created_date FROM ....
 ```
 
 The array items can also be Objects.
 
-#### Aliased Items and Formatting (objects)
+#### Aliased fields and Formatting (objects)
 
-It's sometimes appropriate to alias a field definition, if it's to be renamed, or when using SQL Functions and operators to manipulate the response. E.g. Below we're using the `DATE` function to format the `created_date`, and we're aliasing it so it will be returned with prop key `_date`.
+**Aliasing fields**
+
+It's sometimes appropriate to return a field by another name, this is called *aliasing*.
+
+To achieve that, instead of having a string item in the fields array, an object is provided instead. The object has one property where the key of that property defines the new name, and the value the db field.
+
+e.g. here we rename email to emailAddress
 
 ```js
-dare.get('users',
+await dare.get('users',
 	[
-	  'name',
+		'name', // also including a regular string field alongside for comparison
+		{
+			// label : db field
+			'emailAddress': 'email'
+		}
+	]
+);
+// sql: SELECT email AS emailAddress FROM users ...
+```
+
+**Applying SQL Formatting**
+
+The object structure used for **aliasing** can also be used to label a response including a SQL Function.
+
+E.g. Below we're using the `DATE` function to format the `created_date`, and we're aliasing it so it will be returned with prop key `date`.
+
+```js
+await dare.get('users',
+	[
 	  {
-	  	'_date': 'DATE(created_date)'
+	  	'date': 'DATE(created_date)'
 	  }
 	]
 );
-// sql: SELECT name, DATE(created_date) AS _date ...
+// sql: SELECT name, DATE(created_date) AS date ...
 ```
 
-*Pattern*:
 
-`FUNCTION_NAME([FIELD_PREFIX]? field_name [, ADDITIONAL_PARAMETERS]*)`
+**Supported SQL Functions**:
+
+SQL Functions have to adhere to a pattern. 
+
+*note*: It is currently limited to defining just one table field, we hope this will change
+
+`FUNCTION_NAME([FIELD_PREFIX]? field_name [MATH_OPERATOR MATH_VALUE]?[, ADDITIONAL_PARAMETERS]*)`
 
 - *FUNCTION_NAME*: uppercase, no spaces
 - *FIELD_PREFIX*: optional, uppercase
 - *field_name*: db field reference
+- *MATH_OPERATOR* *MATH_VALUE*: optional
 - *ADDITIONAL_PARAMETERS*: optional, prefixed with `,`, (uppercase, digit or quoted string)
 
 *e.g.*
@@ -366,27 +153,32 @@ Field Defition | Description
 `CONCAT(ROUND(field * 100), '%')` | Multiplying a number by 100. Rounding to 2 decimal places and appending a '%' to the end to convert a decimal value to a percentage.
 `DATE_FORMAT(field, "%Y-%m-%dT%T.%fZ")` | Format date field
 
-In the case of `ROUND()` there is an allowance for `field * [digit]` pattern.
-
 #### Nesting Fields
 
-Objects entries which have Objects as value. In this case they shall attempt to get data from accross multiple tables.
+Nesting can return data structures from across tables. 
+
+*note*: a **Model** Field Attribute `reference`, which defines the join between the two tables, is required to make nested joins.
+
+Request nested data with an object; where the key is the name of the table to be joined, and the value is the Array of fields to return from the joined table.
 
 ```js
-
+	// fields attribute...
 	[
 		'name',
-		'country': {
-			'name'
+		{
+			'country': [
+				'name'
+			]
 		}
 	]
 
-	// sql: SELECT [users.]name, county.name
+	// sql: SELECT name, county.name
 ```
 
 The SQL this creates renames the fields and then recreates the structured format that was requested. So with the above request: a typical response would have the following structure...
 
 ```js
+	// Example response
 	{
 		name: 'Andrew',
 		country: {
@@ -396,7 +188,7 @@ The SQL this creates renames the fields and then recreates the structured format
 ```
 
 - At the moment this only supports *n:1* mapping.
-- The relationship between the tables must be defined in the scheme.
+- The relationship between the tables must be defined in a model field reference.
 
 
 ### Filter `filter`
@@ -416,7 +208,9 @@ e.g.
 	// ... WHERE id = 1 AND is_hidden = 0 ...
 ```
 
-The filter object can contain nested objects (Similar too the Fields Object). Nested objects define conditions on Relational tables.
+The filter object can contain nested objects (Similar to the Fields Object). Nested objects define conditions on Relational tables.
+
+*note*: a **Model** Field Attribute `reference`, which defines the join between the two tables, is required to make nested joins.
 
 
 ```js
@@ -464,13 +258,15 @@ The type of value affects the choice of SQL Condition syntax to use. For example
 
 
 
-#### Negate entire joins (NOT EXISTS)
+#### Negate entire joins (i.e. NOT EXISTS)
+
+*note*: a **Model** Field Attribute `reference`, which defines the join between the two tables, is required to make nested joins.
 
 If there is a nested section on a filter which should act to exclude items from the resultset. Then it can be appropriate to use `-` in front of the table name.
 
 Example: Retrieve all users who are *not* in the 'admin' team....
 ```js
-dare.get({
+await dare.get({
 	table: 'users',
 	fields: ['name'],
 	filter: {
@@ -518,7 +314,9 @@ Generates
 
 ### Join
 
-The Join Object is a Fields=>Value object literal. It accepts similar syntax to the Filter Object, and defines those conditions on the SQL JOIN Condition.
+*note*: a **Model** Field Attribute `reference`, which defines the join between the two tables, is required to make nested joins.
+
+The Join Object is a Fields=>Value object literal. It accepts the same syntax to the Filter Object, and defines those conditions on the SQL JOIN Condition.
 
 e.g.
 
@@ -535,9 +333,9 @@ e.g.
 
 The JOIN object is useful when restricting results in the join table without affecting the results returned in the primary table.
 
-To facilitate scenarios where the optional JOIN tables records are dependent on another relationship we can define this also in the JOIN Object, by passing though an special prop `_required: true` (key=>value)
+To facilitate scenarios where the optional JOIN tables records are dependent on another relationship we can define this also in the JOIN Object, by passing though a special prop `_required: true` (key=>value)
 
-The following statement includes all results from the main table, but does not append the country data unless it is within the continent of 'Europe'
+The following statement includes all rows as before, but the nested country data is filtered separatly.
 
 ```js
 
@@ -559,10 +357,10 @@ The following statement includes all results from the main table, but does not a
 
 ### Pagination `limit` and `start`
 
-The limit and start property are simply applied to the SQL query and can be used to paginate the resultset.
+The `limit` and `start` properties are simply applied to the SQL query and can be used to paginate the resultset.
 
 ```js
-dare.get({
+await dare.get({
 	table: 'table',
 	fields: ['name'],
 	limit: 10, // Return only 10 rows
@@ -572,7 +370,7 @@ dare.get({
 ```
 
 ### No `limit` set and `notfound`
-Dare returns a single item when no `limit` is set. When the item is not found Dare rejects the request with `DareError.NOT_FOUND`. To override this default behaviour simply set the `notfound`. e.g.
+Dare returns a single item when no `limit` is set. When the item is not found Dare rejects the request with `DareError.NOT_FOUND`. To override this default behaviour simply set the `notfound` to the value to respond with in the event of a notfound event being triggered. This can be a simple value or if a function is provided, then that function will be called e.g.
 
 ```js
 const resp = await dare.get({
@@ -590,7 +388,7 @@ console.log(resp); // null
 
 ## dare.getCount(table[, filter][, options])
 
-The `dare.getCount` method builds and executes a `SELECT ...` SQL statement. It returns the number of results which match the request options. And is useful when constructing pagination.
+The `dare.getCount` method like the `dare.get` method builds and executes a `SELECT ...` SQL statement. It differs from the `get` in that it does not operate on the `fields` option. It merely calculates and returns the number of results which match the request options. It is intended to be used when constructing pagination, or other summaries.
 
 | property | Type              | Description
 |----------|-------------------|----------------
@@ -646,7 +444,7 @@ The `dare.post` method is used to build and execute an `INSERT ...` SQL statemen
 e.g.
 
 ```js
-dare.post('user', {name: 'Andrew', profession: 'Mad scientist'});
+await dare.post('user', {name: 'Andrew', profession: 'Mad scientist'});
 // INSERT INTO table (name, profession) VALUES('Andrew', 'Mad scientist')
 ```
 
@@ -657,7 +455,7 @@ Alternatively a options Object can be used instead.
 e.g.
 
 ```js
-dare.post({
+await dare.post({
 	table: 'user',
 	body: {
 		name: 'Andrew',
@@ -674,7 +472,7 @@ The body can be an Array of objects.
 e.g.
 
 ```js
-dare.post({
+await dare.post({
 	table: 'user',
 	body: [{
 		name: 'Andrew',
@@ -687,7 +485,7 @@ dare.post({
 
 This generates `INSERT INTO user (name, profession) VALUES ('Andrew', 'Mad Scientist'), ('Peppa', DEFAULT)`. Note where the key's differ between items in the Array the `DEFAULT` value is inserted instead. 
 
-### Post options (additional)
+### Post `options` (additional)
 
 | Prop          | Type             | Description
 |---------------|------------------|----------------
@@ -707,7 +505,7 @@ Updates records within the `table` with the `body` object when they match `filte
 | options  | Hash (key=>Value) | Additional Options
 
 
-### Patch options (additional)
+### Patch `options` (additional)
 
 | Prop          | Type      | Description
 |---------------|-----------|----------------
@@ -727,13 +525,355 @@ Deletes records within the `table` when they match `filter`.
 | options  | Hash (key=>Value) | Additional Options
 
 
-### Patch options (additional)
+### Del `options` (additional)
 
 | Prop          | Type      | Description
 |---------------|-----------|----------------
 | notfound      | *         | Value to return when there are no affected rows. If it's a function the function will be called. Default throws `DareError.NOT_FOUND`
-| limit         | number    | Default: `1`. Limit the number of results which can be affected by patch
+| limit         | number    | Default: `1`. Limit the number of results which can be affected by delete
 
+
+# `options` Object
+
+The `options` Object is used to define properties on the current and descendent contexts. In other words, every method in Dare, creates a new instances inheritting its parent options as well as defining it's own. See `dare.use(options)` for more.
+
+The `options` themselves are a set of properties used to interpret and manipulate the request.
+
+```js
+// Create an options Object
+const options = {
+	// Some options...
+}
+
+// Apply options at the point where Dare is invoked...
+const dare = new Dare(options);
+
+// OR Apply options when creating an instance off another instance...
+const dare2 = dare.use(options);
+
+// OR Apply options at the point of calling a method...
+await dare.get({
+	table: 'sometable',
+	fields: ['id', 'name'],
+	...options
+})
+```
+
+As you can see, to apply `options` you have... um *options*.
+
+# `options.models`
+
+The `options.models` object, allows us to apply all our models to Dare. Where the object key is the label for which we'll refer to that model.
+
+See next section **Model** for what a model looks like.
+
+
+```js
+// options Object containing a property called `models`
+// Models is a key => model store, where the key is what we'll always refer to as the label for that model.
+const options = {
+	models: {
+		// modelA,
+		// modelB,
+		// etc...
+	}
+}
+
+// options applied to dare as before.
+```
+
+# Model
+
+Perhaps the most important part of the **Dare** library is concept of a **model**.
+
+A **model** defines:
+- how data is interlinked, i.e. how one relational data table is joined to another via a key
+- mutation handlers, for changing requests. This allows access permissions to be applied, to filter results, to restrict or mutate input data.
+
+E.g. here are available properties which can be defined on a model, 
+
+```js
+const myModel = {
+	table, // this is the db table name, if omitted Dare will assume the models label instead
+	schema, // A schema object defining fields, as well as their relationship to other models.
+	get, // Function to modify the request when accessing data
+	post, // Function to modify the request when posting data
+	patch, // Function to modify the request when patching data
+	del, // Function to modify the request when deleting data
+}
+```
+
+## Model Schema `schema`
+
+The `schema` property defines an object, containing field attribute references in key=>value pair, i.e. `fieldName (key) => field attributes (value)`.
+
+```js
+const mySchema = {
+	id, // id field attributes
+	name, // name field attributes
+	//etc...
+}
+```
+
+### Field Attributes
+
+Can define how a field corresponds to a DB table field, whether it's readable/writable, is it a generated field, as well as relationships between models.
+
+Defining a field attribute, can be verbose using an object with special keys, or can be shorthanded with specific datatypes
+
+Property | Attr Example | Shorthand DataType | ShortHand Example | Description
+--|--|--|--
+`reference` | e.g. `{reference: ['country.id']}` | `Array` | `county_id: ['country.id']` | Relationship with other models
+`alias` | e.g. `{alias: 'email'}` | `String` | `emailAddress: 'email'` | Alias a field with a DB Table field
+`handler` | e.g. `{handler: Function}` | `Function` | `url: urlFunction` | Generated Field
+`type` | e.g. `{type: 'json'}` | na | na | Type of data in field, this has various uses.
+`readable` | e.g. `{readable: false}` | na | na | Disables/Enables request access to a field
+`writeable` | e.g. `{writeable: false}` | na | na | Disables/Enables write access to a field
+na | e.g. `{writeable: false: readable: false}` | `Boolean` | `{password: false}` | Disables/Enables both write and read access to a field
+
+
+Fields dont need to be explicitly defined in the `options.models.*tbl*.schema` where they map one to one with a DB table fields the request will just go through verbatim.
+
+
+#### Field attribute: `reference`
+
+In the example below the fields `users.country_id` defines a reference with `country.id` which is used to construct SQL JOIN Conditions.
+
+
+```js
+const dare = new Dare({
+	models : {
+		users: {
+			schema: {
+				// users fields...
+				country_id: ['country.id']
+			},
+		},
+		country: {
+			schema: {
+				// country fields...
+			},
+		}
+	}
+});
+```
+
+#### Field attribute: `type`
+
+Defining the `type` introduces additional features.
+
+**`datatime`**
+
+Setting value to 'datetime', a conditional filter short hand for `created_time: 2017` would be expanded to `created_time BETWEEN '2017-01-01T00:00:00' AND '2017-12-31T23:59:59`
+
+```js
+const dare = new Dare({
+	models: {
+		users: {
+			schema: {
+				created_time: {
+					type: 'datetime'
+				}
+			}
+		}
+	}
+});
+```
+
+**`json`**
+
+Serializes Objects and Deserializes JSON strings in `get`, `post` and `patch` operations.
+
+e.g.
+
+Schema: field definition...
+```js
+const dare = new Dare({
+	models: {
+		users: {
+			schema: {
+				meta: {
+					// Define a field meta with data type of json
+					type: 'json'
+				}
+			}
+		}
+	}
+});
+```
+
+Example set and get
+```js
+	// Arbitary object...
+	const meta = {
+		prop1: 1,
+		prop2: 2
+	};
+
+	// For a field named `meta`
+	const {insertId: id} = await dare.post('users', {meta});
+	// The value is run through JSON.stringify before insertion
+	// INSERT INOT users (meta) VALUES('{"prop1": 1, "prop2": 2}')
+
+
+	...
+
+	// The value is desiralized, when accessed via get...
+	const {meta} = await dare.get('users', ['meta'], {id});
+
+	// e.g...
+	console.log(meta);
+	// Object({
+	// 	prop1: 1,
+	// 	prop2: 2
+	// });
+
+```
+
+
+#### Field attribute: `handler`
+
+When the value is a function, the function will be invoked when interpretting the request as part of a field value. The response of this function can either be a static value or it can be an additional function which is optionally run on all items in the response, to return a generated field.
+
+E.g.
+
+This will manipulate the request and response to create the property `avatar_url` on the fly.
+
+```js
+const dare = new Dare({
+	models: {
+		users: {
+			schema: {
+				avatar_url(fields) {
+
+					fields.push('id'); // require additional field from users table.
+
+					return (item) => `/images/avatars/${item.id}`;
+				}
+			}
+		}
+	}
+});
+```
+
+#### Field attribute: `alias`
+
+To alias a field, so that you can use a name different to the db column name, assign it a string name of the field in the current table. e.g. `emailAddress: 'email'`
+
+
+```js
+const dare = new Dare({
+	models: {
+		users: {
+			schema: {
+				emailAddress: 'email'
+			}
+		}
+	}
+});
+```
+
+For example this will allow us to use the alias `emailAddress` in our api (see below), but the SQL generated will refer to it with it's true field name "`email`".
+
+```js
+await dare.get('users', ['emailAddress'], {emailAddress: 'andrew@%'});
+// SELECT email AS emailAddress FROM users WHERE email LIKE 'andrew@%'
+
+await dare.post('users', {emailAddress: 'andrew@example.com'});
+// INSERT INTO users (email) VALUES ('andrew@example.com')
+
+```
+
+The aliasing can also be used for common functions and define fields on another table to abstract away some of the complexity in your relational schema and provide a cleaner api interface.
+
+e.g.
+```js
+const dare = new Dare({
+	models: {
+		users: {
+			schema: {
+				emailAddress: {
+					// Explicitly define the alias
+					// Reference the email define on another table, we can also wrap in SQL functions.
+					alias: 'LOWER(usersEmails.email)'
+				}
+			}
+		},
+		// Any cross table join needs fields to map
+		usersEmails: {
+			schema: {
+				user_id: ['users.id']
+			}
+		}
+	}
+});
+```
+
+#### Field attribute: `readable`/`writeable`
+
+A flag to control access to a field
+
+```js
+const dare = new Dare({
+	models: {
+		users: {
+			schema: {
+				// Explicit object
+				id: {
+					readable: true,
+					writeable: false // non-writeable
+				},
+
+				// Shorthand for non-readable + non-writeable
+				password: false 
+			}
+		}
+	}
+})
+```
+
+With the above `writeable`/`readable` field definitions an error is thrown whenever attempting to access the field e.g.
+
+```js
+await dare.get('users', ['password'], {id: 123});
+// throws {code: INVALID_REFERENCE}
+```
+
+Or when trying to modify a field through `post` or `patch` methods, e.g.
+
+```js
+await dare.patch('users', {id: 321}, {id: 1337});
+// throws {code: INVALID_REFERENCE}
+```
+
+
+## `model.get`
+
+Here's an example of setting a model to be invoked whenever we access `users` model, we'll go into each of the properties afterwards.
+
+```js
+function get(options) {
+	options.filter.deleted = null;
+}
+
+// For completeness we'll assume the new Dare instance approach for adding the options...
+const dare = new Dare({
+	models: {
+		users: {
+			get
+		}
+	}
+});
+
+// Here we're using `table:users`, so the model's `get` Function would be invoked
+await dare.get({
+	table: 'users',
+	fields: ['name'],
+	limit: 100
+});
+
+// SELECT name FROM users WHERE deleted = false LIMIT 100;
+```
 
 
 # Additional Options
@@ -753,7 +893,7 @@ E.g. Define 'author' as an alternative for 'users'
 Example implementation...
 
 ```js
-dare.get({
+await dare.get({
 	table: comments,
 	fields: {
 		id,
@@ -774,7 +914,7 @@ E.g. Include all the tags associated with users AND only show users whom include
 
 
 ```js
-dare.get({
+await dare.get({
 	table: 'users',
 	fields: ['name', {'tags': ['name']}],
 	filter: {
@@ -897,7 +1037,7 @@ const Dare = require('dare');
 // Initiate it
 const dare = new Dare();
 
-dare.MAX_LIMIT = 1000000;
+await dare.MAX_LIMIT = 1000000;
 ```
 
 
@@ -912,7 +1052,7 @@ E.g.
 dare = dare.use(); 
 
 // Define a response_row_handler on the new instance...
-dare.response_row_handler = (item) => {
+await dare.response_row_handler = (item) => {
 	// rudimentary write out as CSV.
 	res.write(Object.keys(item).join(',') + '\n');
 

--- a/src/format/join_handler.js
+++ b/src/format/join_handler.js
@@ -10,7 +10,7 @@ const getFieldAttributes = require('../utils/field_attributes');
  */
 module.exports = function(join_object, root_object, dareInstance) {
 
-	const {schema} = dareInstance.options;
+	const {models} = dareInstance.options;
 
 	const {table: rootTable, alias: _rootAlias} = root_object;
 	const {table: joinTable, alias: _joinAlias} = join_object;
@@ -45,7 +45,7 @@ module.exports = function(join_object, root_object, dareInstance) {
 
 		for (const _b of b) {
 
-			join_conditions = links(schema[_a], _b) || invert_links(schema[_b], _a);
+			join_conditions = links(models[_a]?.schema, _b) || invert_links(models[_b]?.schema, _a);
 			if (join_conditions) {
 
 				break;
@@ -69,7 +69,7 @@ module.exports = function(join_object, root_object, dareInstance) {
 	}
 
 	// Crawl the schema for an intermediate table which is linked to both tables. link table, ... we're only going for a single Kevin Bacon. More than that and the process will deem this operation too hard.
-	for (const linkTable in schema) {
+	for (const linkTable in models) {
 
 		// Well, this would be silly otherwise...
 		if (linkTable === joinTable || linkTable === rootTable) {
@@ -79,9 +79,9 @@ module.exports = function(join_object, root_object, dareInstance) {
 		}
 
 		// LinkTable <> joinTable?
-		const sjt = schema[joinAlias] || schema[joinTable];
-		const jt = schema[joinAlias] ? joinAlias : joinTable;
-		const join_conditions = links(sjt, linkTable) || invert_links(schema[linkTable], jt);
+		const sjt = models[joinAlias]?.schema || models[joinTable]?.schema;
+		const jt = models[joinAlias]?.schema ? joinAlias : joinTable;
+		const join_conditions = links(sjt, linkTable) || invert_links(models[linkTable]?.schema, jt);
 
 
 		if (!join_conditions) {
@@ -91,7 +91,7 @@ module.exports = function(join_object, root_object, dareInstance) {
 		}
 
 		// RootTable <> linkTable
-		const root_conditions = links(schema[linkTable], rootTable) || invert_links(schema[rootTable], linkTable);
+		const root_conditions = links(models[linkTable]?.schema, rootTable) || invert_links(models[rootTable]?.schema, linkTable);
 
 		if (!root_conditions) {
 
@@ -118,14 +118,14 @@ module.exports = function(join_object, root_object, dareInstance) {
 
 };
 
-function links(tableObj, joinTable, flipped = false) {
+function links(tableSchema, joinTable, flipped = false) {
 
 	const map = {};
 
 	// Loop through the table fields
-	for (const field in tableObj) {
+	for (const field in tableSchema) {
 
-		const {references} = getFieldAttributes(tableObj[field]);
+		const {references} = getFieldAttributes(tableSchema[field]);
 
 		let ref = references || [];
 

--- a/src/format_request.js
+++ b/src/format_request.js
@@ -90,8 +90,8 @@ async function format_request(options, dareInstance) {
 
 	}
 
-	const {schema = {}} = dareInstance.options;
-	const table_schema = schema[table] || {};
+
+	const {schema: table_schema = {}} = (dareInstance.options.models && dareInstance.options.models[table]) || {};
 
 
 	// Set the prefix if not already

--- a/src/format_request.js
+++ b/src/format_request.js
@@ -61,6 +61,9 @@ async function format_request(options, dareInstance) {
 
 	}
 
+	// Get the model
+	const model = dareInstance.options.models?.[table] || {};
+
 	/**
 	 * Call bespoke table handler
 	 * This may modify the incoming options object, ammend after handler, etc...
@@ -68,19 +71,14 @@ async function format_request(options, dareInstance) {
 	{
 
 		const {method} = dareInstance.options;
-		const handlers = dareInstance.options[method] || {};
-		let handler;
 
-		if (table in handlers) {
+		// If the model does not define the method
+		const handler = (method in model
+			? model[method]
+			// Or use the default model
+			: dareInstance.options.models?.default?.[method]
+		);
 
-			handler = handlers[table];
-
-		}
-		else if ('default' in handlers) {
-
-			handler = handlers.default;
-
-		}
 		if (handler) {
 
 			// Trigger the handler which alters the options...
@@ -91,7 +89,7 @@ async function format_request(options, dareInstance) {
 	}
 
 
-	const {schema: table_schema = {}} = (dareInstance.options.models && dareInstance.options.models[table]) || {};
+	const {schema: table_schema = {}} = model;
 
 
 	// Set the prefix if not already

--- a/src/index.js
+++ b/src/index.js
@@ -283,8 +283,8 @@ Dare.prototype.patch = async function patch(table, filter, body, opts = {}) {
 	// Validate Body
 	validateBody(req.body);
 
-	// Get the schema
-	const tableSchema = _this.options.schema && _this.options.schema[req.table];
+	// Get the model structure
+	const {schema: tableSchema} = (_this.options.models && _this.options.models[req.table]) || {};
 
 	// Prepare post
 	const {assignments, preparedValues} = prepareSet(req.body, tableSchema);
@@ -371,7 +371,7 @@ Dare.prototype.post = async function post(table, body, opts = {}) {
 	const exec = req.ignore ? 'IGNORE' : '';
 
 	// Get the schema
-	const tableSchema = _this.options.schema && _this.options.schema[req.table];
+	const {schema: tableSchema} = (_this.options.models && _this.options.models[req.table]) || {};
 
 	// Capture keys
 	const fields = [];

--- a/src/index.js
+++ b/src/index.js
@@ -27,10 +27,13 @@ module.exports.DareError = DareError;
  * @param {object} options - Initial options defining the instance
  * @returns {object} instance of dare
  */
-function Dare(options) {
+function Dare(options = {}) {
+
+	// Backwards compatibility for {schema}
+	migrateToModels(options);
 
 	// Overwrite default properties
-	this.options = options || {};
+	this.options = options;
 
 	return this;
 
@@ -111,6 +114,9 @@ Dare.prototype.after = function(resp) {
 Dare.prototype.use = function(options = {}) {
 
 	const inst = Object.create(this);
+
+	// Backwards compatibility for {schema}
+	migrateToModels(options);
 
 	// Create a new options, merging inheritted and new
 	inst.options = extend(clone(this.options), options);
@@ -683,5 +689,30 @@ function formCondition(field, condition) {
 
 	// Insert the field name in place
 	return condition.includes('$$') ? condition.replace(/\$\$/g, field) : `${field} ${condition}`;
+
+}
+
+/**
+ * Migrate to Models
+ * Backwards compatibility for {schema}
+ * @param {object} options - Options object
+ * @returns {void} Extends paramater
+ */
+function migrateToModels(options) {
+
+	// Legacy input...
+	if (options.schema && !options.models) {
+
+		options.models = {};
+
+		for (const table in options.schema) {
+
+			options.models[table] = {
+				schema: options.schema[table]
+			};
+
+		}
+
+	}
 
 }

--- a/src/index.js
+++ b/src/index.js
@@ -700,16 +700,31 @@ function formCondition(field, condition) {
  */
 function migrateToModels(options) {
 
+	if (options.models) {
+
+		// Nothing to do
+		return;
+
+	}
+
 	// Legacy input...
-	if (options.schema && !options.models) {
+	for (const prop in options) {
 
-		options.models = {};
+		if (!['schema', 'patch', 'post', 'del', 'get'].includes(prop) || !options[prop]) {
 
-		for (const table in options.schema) {
+			continue;
 
-			options.models[table] = {
-				schema: options.schema[table]
-			};
+		}
+
+		for (const table in options[prop]) {
+
+			extend(options, {
+				models: {
+					[table]: {
+						[prop]: options[prop][table]
+					}
+				}
+			});
 
 		}
 

--- a/test/data/options.js
+++ b/test/data/options.js
@@ -3,107 +3,135 @@ const created_time = {
 };
 
 module.exports = {
-	schema: {
+	models: {
 		// Users table
 		users: {
-			/*
-			 * Field alias
-			 * The DB schema defines `email` however our business requires that we can alias it as emailAddress
-			 */
-			emailAddress: 'email',
 
-			/*
-			 * Field reference
-			 * The users.country_id references the country.id column, this is used for making joins
-			 */
-			country_id: 'country.id',
+			schema: {
+				/*
+				 * Field alias
+				 * The DB schema defines `email` however our business requires that we can alias it as emailAddress
+				 */
+				emailAddress: 'email',
 
-			/*
-			 * JSON data type
-			 */
-			meta: {
-				type: 'json'
-			},
+				/*
+				 * Field reference
+				 * The users.country_id references the country.id column, this is used for making joins
+				 */
+				country_id: 'country.id',
 
-			/**
-			 * Url generated
-			 * @param {Array} fields - Array of current fields
-			 * @returns {string|Function} Can return a function or a field definition.
-			 */
-			url(fields) {
+				/*
+				 * JSON data type
+				 */
+				meta: {
+					type: 'json'
+				},
 
-				// This is a generated function
-				fields.push('id');
+				/**
+				 * Url generated
+				 * @param {Array} fields - Array of current fields
+				 * @returns {string|Function} Can return a function or a field definition.
+				 */
+				url(fields) {
 
-				return ({id}) => `/user/${id}`;
+					// This is a generated function
+					fields.push('id');
 
-			},
+					return ({id}) => `/user/${id}`;
 
-			/*
-			 * Date Type
-			 */
-			created_time
+				},
+
+				/*
+				 * Date Type
+				 */
+				created_time
+			}
+
 		},
 
 		// Users have multiple emails
 		users_email: {
 
-			/*
-			 * User_id defines a field which references the users table
-			 */
-			user_id: {
-				references: ['users.id']
-			},
+			schema: {
 
-			/*
-			 * Date Type
-			 */
-			created_time
+				/*
+				 * User_id defines a field which references the users table
+				 */
+				user_id: {
+					references: ['users.id']
+				},
+
+				/*
+				 * Date Type
+				 */
+				created_time
+			}
 		},
-
 		country: {
-			/*
-			 * Date Type
-			 */
-			created_time
+
+			schema: {
+
+				/*
+				 * Date Type
+				 */
+				created_time
+			}
+
 		},
 
 		comments: {
-			author_id: {
-				references: 'users.id'
-			},
-			/*
-			 * Date Type
-			 */
-			created_time
+
+			schema: {
+
+				author_id: {
+					references: 'users.id'
+				},
+				/*
+				 * Date Type
+				 */
+				created_time
+			}
 		},
 
 		activityEvents: {
-			session_id: {
-				references: 'activitySession.id'
-			},
-			ref_id: 'apps.id',
 
-			/*
-			 * Date Type
-			 */
-			created_time
+			schema: {
+
+				session_id: {
+					references: 'activitySession.id'
+				},
+
+				ref_id: 'apps.id',
+
+				/*
+				 * Date Type
+				 */
+				created_time
+			}
 		},
 
 		apps: {
-			/*
-			 * Date Type
-			 */
-			created_time
+
+			schema: {
+
+				/*
+				 * Date Type
+				 */
+				created_time
+			}
 		},
 
 		assetDomains: {
-			asset_id: 'apps.id',
 
-			/*
-			 * Date Type
-			 */
-			created_time
+			schema: {
+
+				asset_id: 'apps.id',
+
+				/*
+				 * Date Type
+				 */
+				created_time
+			}
 		}
 
 	},

--- a/test/integration/get.spec.js
+++ b/test/integration/get.spec.js
@@ -2,12 +2,15 @@ const Dare = require('../../src');
 // DEBUG const mysql = require('mysql2/promise');
 
 const {db} = global;
-const schema = {
+const models = {
 	teams: {},
 	users: {},
 	userTeams: {
-		'user_id': ['users.id'],
-		'team_id': ['teams.id']
+
+		schema: {
+			'user_id': ['users.id'],
+			'team_id': ['teams.id']
+		}
 	}
 };
 
@@ -20,7 +23,7 @@ describe('dare init tests', () => {
 	beforeEach(() => {
 
 		// Initiate
-		dare = new Dare({schema});
+		dare = new Dare({models});
 
 		// Set a test instance
 		// eslint-disable-next-line arrow-body-style

--- a/test/specs/after.js
+++ b/test/specs/after.js
@@ -14,12 +14,14 @@ describe('after Handler', () => {
 		 * Setup test schema
 		 */
 		dare = dare.use({
-			schema: {
+			models: {
 				'users': {
 
 				},
 				'emails': {
-					user_id: 'users.id'
+					schema: {
+						user_id: 'users.id'
+					}
 				}
 			},
 			meta: {

--- a/test/specs/after.js
+++ b/test/specs/after.js
@@ -186,21 +186,23 @@ describe('after Handler', () => {
 	describe('should be overrideable by the pre-handler', () => {
 
 		const new_after_handler = () => 'overriden';
-		const preHandlers = {
-			users() {
+		const preHandlers = (options, dareInstance) => {
 
-				// This will override it...
-				this.after = new_after_handler;
+			// This will override it...
+			dareInstance.after = new_after_handler;
 
-			}
 		};
 
 		beforeEach(() => {
 
-			dare.options.get = preHandlers;
-			dare.options.post = preHandlers;
-			dare.options.patch = preHandlers;
-			dare.options.del = preHandlers;
+			dare.options.models = {
+				users: {
+					get: preHandlers,
+					post: preHandlers,
+					patch: preHandlers,
+					del: preHandlers
+				}
+			};
 
 			// Overwrite execute
 			dare.execute = async () => ([{}]);

--- a/test/specs/delete.js
+++ b/test/specs/delete.js
@@ -101,9 +101,9 @@ describe('del', () => {
 
 		};
 
-		dare.options = {
-			del: {
-				'tbl': req => {
+		dare.options.models = {
+			'tbl': {
+				del(req) {
 
 					// Augment the request
 					req.filter.id = 1;
@@ -131,10 +131,10 @@ describe('del', () => {
 
 		};
 
-		dare.options = {
-			del: {
+		dare.options.models = {
+			default: {
 				// Augment the request
-				async default(req) {
+				async del(req) {
 
 					req.filter.id = 1;
 
@@ -154,9 +154,9 @@ describe('del', () => {
 
 		const msg = 'test';
 
-		dare.options = {
-			del: {
-				'default': () => {
+		dare.options.models = {
+			default: {
+				del() {
 
 					// Augment the request
 					throw new Error(msg);
@@ -177,9 +177,9 @@ describe('del', () => {
 
 	it('should return options.skip if set and not trigger further operations', async () => {
 
-		dare.options = {
-			del: {
-				'default': options => {
+		dare.options.models = {
+			default: {
+				del(options) {
 
 					options.skip = true;
 
@@ -188,6 +188,28 @@ describe('del', () => {
 		};
 
 		const resp = await dare
+			.del({
+				table: 'tbl',
+				filter: {id: 2}
+			});
+
+		expect(resp).to.eql(true);
+
+	});
+
+	it('legacy: options.schema, should return options.skip if set and not trigger further operations', async () => {
+
+		const dare2 = dare.use({
+			del: {
+				default(options) {
+
+					options.skip = true;
+
+				}
+			}
+		});
+
+		const resp = await dare2
 			.del({
 				table: 'tbl',
 				filter: {id: 2}

--- a/test/specs/field_access.js
+++ b/test/specs/field_access.js
@@ -9,15 +9,17 @@ describe('field access', () => {
 	beforeEach(() => {
 
 		dare = new Dare({
-			schema: {
+			models: {
 				'users': {
+					schema: {
 
-					// Write is disabled, whilst id is readable
-					'id': {
-						writeable: false
-					},
-					// Password is not readable or writable
-					'password': false
+						// Write is disabled, whilst id is readable
+						'id': {
+							writeable: false
+						},
+						// Password is not readable or writable
+						'password': false
+					}
 				}
 			}
 		});

--- a/test/specs/field_alias.js
+++ b/test/specs/field_alias.js
@@ -11,13 +11,17 @@ describe('field alias', () => {
 
 		// If the storage wants to use 'email', but the interface would optionally like to use 'emailAddress'
 		dare = new Dare({
-			schema: {
+			models: {
 				'users': {
-					'emailAddress': 'email',
-					'country_id': 'country.id'
+					schema: {
+						'emailAddress': 'email',
+						'country_id': 'country.id'
+					}
 				},
 				'comments': {
-					'user_id': 'users.id'
+					schema: {
+						'user_id': 'users.id'
+					}
 				}
 			}
 		});

--- a/test/specs/format_request.js
+++ b/test/specs/format_request.js
@@ -18,7 +18,7 @@ describe('format_request', () => {
 
 		// Create an execution instance
 		dare = dare.use({
-			schema: {}
+			models: {}
 		});
 
 	});
@@ -100,8 +100,10 @@ describe('format_request', () => {
 		beforeEach(() => {
 
 			dare.options = {
-				schema: {
-					'asset': {tbl_id: 'tbl.id'}
+				models: {
+					'asset': {
+						schema: {tbl_id: 'tbl.id'}
+					}
 				}
 			};
 
@@ -429,23 +431,25 @@ describe('format_request', () => {
 
 		describe(condition_type, () => {
 
-			describe('should prep conditions', () => {
+			const table = 'table';
 
-				const table = 'table';
+			beforeEach(() => {
 
-				beforeEach(() => {
-
-					dare.options = {
-						schema: {
-							[table]: {
+				dare.options = {
+					models: {
+						[table]: {
+							schema: {
 								date: {
 									type: 'datetime'
 								}
 							}
 						}
-					};
+					}
+				};
 
-				});
+			});
+
+			describe('should prep conditions', () => {
 
 				const a = [
 					[
@@ -700,16 +704,6 @@ describe('format_request', () => {
 
 					it(`should augment filter values ${date}`, async () => {
 
-						dare.options = {
-							schema: {
-								[table]: {
-									date: {
-										type: 'datetime'
-									}
-								}
-							}
-						};
-
 						const resp = await dare.format_request({
 							table,
 							fields: ['id'],
@@ -732,12 +726,12 @@ describe('format_request', () => {
 
 	describe('table_alias_handler', () => {
 
-		const schema = {
+		const models = {
 			asset: {
-				name: {}
+				schema: {name: {}}
 			},
 			events: {
-				asset_id: 'asset.id'
+				schema: {asset_id: 'asset.id'}
 			}
 		};
 
@@ -745,7 +739,7 @@ describe('format_request', () => {
 		it('should use options.table_alias_handler for interpretting the table names', async () => {
 
 			dare.options = {
-				schema
+				models
 			};
 
 			dare.table_alias_handler = table => ({'events': 'events', 'alias': 'asset'}[table]);
@@ -769,7 +763,7 @@ describe('format_request', () => {
 		it('should use the options.table_alias hash if no handler is defined', async () => {
 
 			dare.options = {
-				schema,
+				models,
 				table_alias: {
 					'events': 'events',
 					'alias': 'asset'
@@ -797,7 +791,7 @@ describe('format_request', () => {
 			it('should throw an DareError if falsly on join table', () => {
 
 				dare.options = {
-					schema
+					models
 				};
 
 				dare.table_alias_handler = table_alias => ({'public': 'public'}[table_alias]);
@@ -828,9 +822,13 @@ describe('format_request', () => {
 
 			// Redefine the structure
 			dare.options = {
-				schema: {
-					asset: {name: {}},
-					comments: {name: {}}
+				models: {
+					asset: {
+						schema: {name: {}}
+					},
+					comments: {
+						schema: {name: {}}
+					}
 				}
 			};
 
@@ -855,12 +853,16 @@ describe('format_request', () => {
 
 			// Redefine the structure
 			dare.options = {
-				schema: {
-					asset: {name: {}},
+				models: {
+					asset: {
+						schema: {name: {}}
+					},
 					comments: {
-						name: {},
-						asset_id: {
-							references: 'asset.id'
+						schema: {
+							name: {},
+							asset_id: {
+								references: 'asset.id'
+							}
 						}
 					}
 				}
@@ -883,17 +885,21 @@ describe('format_request', () => {
 
 			// Redefine the structure
 			dare.options = {
-				schema: {
-					asset: {name: {}},
+				models: {
+					asset: {
+						schema: {name: {}}
+					},
 					assetType: {
 						// References can be as simple as a string to another [table].[field]
-						asset_id: 'asset.id'
+						schema: {asset_id: 'asset.id'}
 					},
 					comments: {
-						name: {},
-						asset_id: {
-							// There can also be multiple references to connect more than one table on this key...
-							references: ['asset.id', 'assetType.asset_id']
+						schema: {
+							name: {},
+							asset_id: {
+								// There can also be multiple references to connect more than one table on this key...
+								references: ['asset.id', 'assetType.asset_id']
+							}
 						}
 					}
 				}
@@ -919,13 +925,13 @@ describe('format_request', () => {
 
 			// Here the schema is a series of tables a street, belongs to 1 town and in return 1 country
 			dare.options = {
-				schema: {
+				models: {
 					street: {
 						// References can be as simple as a string to another [table].[field]
-						town_id: 'town.id'
+						schema: {town_id: 'town.id'}
 					},
 					town: {
-						country_id: 'country.id'
+						schema: {country_id: 'country.id'}
 					},
 					country: {}
 				}
@@ -1012,10 +1018,10 @@ describe('format_request', () => {
 			const removed = {removed: false};
 
 			dare.options = {
-				schema: {
-					users: {},
+				models: {
+					users: {schema: {}},
 					comments: {
-						'user_id': 'users.id'
+						schema: {'user_id': 'users.id'}
 					}
 				},
 				get: {

--- a/test/specs/format_request.js
+++ b/test/specs/format_request.js
@@ -961,15 +961,15 @@ describe('format_request', () => {
 		it('should pass through exceptions raised in the method handlers', async () => {
 
 			const msg = 'snap';
-			dare.options = {
-				get: {
-					users() {
+			dare.options.method = method;
+			dare.options.models = {
+				users: {
+					get() {
 
 						throw Error(msg);
 
 					}
-				},
-				method: 'get'
+				}
 			};
 
 			const test = dare.format_request({
@@ -987,9 +987,10 @@ describe('format_request', () => {
 
 		it('should pass through the table scoped request', async () => {
 
-			dare.options = {
-				get: {
-					users(options) {
+			dare.options.method = method;
+			dare.options.models = {
+				users: {
+					get(options) {
 
 						// Add something to the filter...
 						options.filter = {
@@ -997,8 +998,7 @@ describe('format_request', () => {
 						};
 
 					}
-				},
-				method: 'get'
+				}
 			};
 
 			const options = await dare.format_request({
@@ -1017,21 +1017,23 @@ describe('format_request', () => {
 
 			const removed = {removed: false};
 
-			dare.options = {
-				models: {
-					users: {schema: {}},
-					comments: {
-						schema: {'user_id': 'users.id'}
-					}
-				},
-				get: {
-					users(options) {
+			dare.options.method = method;
+			dare.options.models = {
+				users: {
+					schema: {},
+					get(options) {
 
 						// Add a filter to users to only show user who haven't been removed
 						options.filter = removed;
 
+					}
+				},
+				comments: {
+					schema: {
+						// Join definition to users model
+						'user_id': 'users.id'
 					},
-					comments(options) {
+					get(options) {
 
 						/*
 						 * We show comments if the user hasn't been deleted
@@ -1048,8 +1050,7 @@ describe('format_request', () => {
 						}
 
 					}
-				},
-				method
+				}
 			};
 
 			/*
@@ -1089,9 +1090,10 @@ describe('format_request', () => {
 		it('should await the response from a promise', () => {
 
 			const msg = 'snap';
-			dare.options = {
-				get: {
-					users() {
+			dare.options.method = method;
+			dare.options.models = {
+				users: {
+					get() {
 
 						return new Promise((resolve, reject) => {
 
@@ -1100,8 +1102,7 @@ describe('format_request', () => {
 						});
 
 					}
-				},
-				method: 'get'
+				}
 			};
 
 			const test = dare.format_request({
@@ -1122,16 +1123,16 @@ describe('format_request', () => {
 			let dareInstance;
 			let that;
 
-			dare.options = {
-				get: {
-					users(options, _dareInstance) {
+			dare.options.method = method;
+			dare.options.models = {
+				users: {
+					get(options, _dareInstance) {
 
 						dareInstance = _dareInstance;
 						that = this;
 
 					}
-				},
-				method: 'get'
+				}
 			};
 
 			dare.format_request({

--- a/test/specs/get-join.js
+++ b/test/specs/get-join.js
@@ -595,37 +595,41 @@ describe('get - request object', () => {
 
 			// Create handler for 'asset.thumbnail'
 			dare.options = {
-				schema: {
+				models: {
 					'assets': {
-						picture_id: 'picture.id',
-						thumbnail(fields) {
+						schema: {
+							picture_id: 'picture.id',
+							thumbnail(fields) {
 
-							// Update the current fields array to include any dependencies missing
-							fields.push('id');
+								// Update the current fields array to include any dependencies missing
+								fields.push('id');
 
-							// Return either a SQL string or a function to run on the response object
-							return obj => `/asset/${obj.id}/thumbnail`;
+								// Return either a SQL string or a function to run on the response object
+								return obj => `/asset/${obj.id}/thumbnail`;
 
-						},
-						url(fields) {
+							},
+							url(fields) {
 
-							// Update the current fields array to include any dependencies missing
-							fields.push('id');
+								// Update the current fields array to include any dependencies missing
+								fields.push('id');
 
-							// Return either a SQL string or a function to run on the response object
-							return obj => `/asset/${obj.id}/url`;
+								// Return either a SQL string or a function to run on the response object
+								return obj => `/asset/${obj.id}/url`;
 
+							}
 						}
 					},
 					'picture': {
-						url(fields) {
+						schema: {
+							url(fields) {
 
-							// Update the current fields array to include any dependencies missing
-							fields.push('id');
+								// Update the current fields array to include any dependencies missing
+								fields.push('id');
 
-							// Return either a SQL string or a function to run on the response object
-							return obj => `${this.options.meta.root}/picture/${obj.id}/image`;
+								// Return either a SQL string or a function to run on the response object
+								return obj => `${this.options.meta.root}/picture/${obj.id}/image`;
 
+							}
 						}
 					}
 				}

--- a/test/specs/get-subquery.js
+++ b/test/specs/get-subquery.js
@@ -8,7 +8,7 @@ let dare;
 
 // Create a schema
 const options = {
-	schema: {
+	models: {
 
 		// Define Datasets
 		assets: {},
@@ -16,13 +16,17 @@ const options = {
 
 		// Define a table to associate datasets
 		assetCollections: {
-			asset_id: 'assets.id',
-			collection_id: 'collections.id'
+			schema: {
+				asset_id: 'assets.id',
+				collection_id: 'collections.id'
+			}
 		},
 
 		// Collection children
 		collectionChildren: {
-			collection_id: 'collections.id'
+			schema: {
+				collection_id: 'collections.id'
+			}
 		}
 	}
 };
@@ -301,9 +305,9 @@ describe('get - subquery', () => {
 		};
 
 		dare.options = {
-			schema: {
+			models: {
 				userEmails: {
-					user_id: 'users.id'
+					schema: {user_id: 'users.id'}
 				}
 			}
 		};

--- a/test/specs/init.js
+++ b/test/specs/init.js
@@ -13,11 +13,11 @@ describe('Dare', () => {
 
 	it('should define default options', () => {
 
-		const schema = {};
+		const models = {};
 		const dare = new Dare({
-			schema
+			models
 		});
-		expect(dare.options).to.have.property('schema', schema);
+		expect(dare.options).to.have.property('models', models);
 
 	});
 
@@ -47,10 +47,12 @@ describe('Dare', () => {
 		beforeEach(() => {
 
 			options = {
-				schema: {
+				models: {
 					'users': {
-						name: {
-							type: 'string'
+						schema: {
+							name: {
+								type: 'string'
+							}
 						}
 					}
 				}
@@ -72,7 +74,7 @@ describe('Dare', () => {
 			expect(dareChild.options).to.have.property('limit', 100);
 
 			// Check the child retains parent properties
-			expect(dareChild.options).to.have.property('schema');
+			expect(dareChild.options).to.have.property('models');
 			expect(dareChild.execute).to.equal(dare.execute);
 
 			// Check the parent was not affected by the child configuration
@@ -83,14 +85,16 @@ describe('Dare', () => {
 		it('should inherit but not leak when extending schema', () => {
 
 			const options2 = {
-				schema: {
+				models: {
 					'users': {
-						name: {
-							writable: false
+						schema: {
+							name: {
+								writable: false
+							}
 						}
 					},
 					'different': {
-						'fields': true
+						schema: {'fields': true}
 					}
 				}
 			};
@@ -102,18 +106,18 @@ describe('Dare', () => {
 			const dare2 = dare.use(options2);
 
 			// Should not share same objects as instance it extended
-			expect(dare.options.schema.users)
-				.to.not.equal(dare2.options.schema.users);
+			expect(dare.options.models.users)
+				.to.not.equal(dare2.options.models.users);
 
 			// Should not mutate instance it extended
-			expect(dare.options.schema.different)
+			expect(dare.options.models.different)
 				.to.be.undefined;
 
-			expect(dare.options.schema.users.name.writable)
-				.to.not.equal(dare2.options.schema.users.name.writable);
+			expect(dare.options.models.users.schema.name.writable)
+				.to.not.equal(dare2.options.models.users.schema.name.writable);
 
 			// Should merge settings for field definitiions... e.g.
-			expect(dare2.options.schema.users)
+			expect(dare2.options.models.users.schema)
 				.to.deep.equal({
 					name: {
 						type: 'string',

--- a/test/specs/init.js
+++ b/test/specs/init.js
@@ -21,6 +21,23 @@ describe('Dare', () => {
 
 	});
 
+	it('should define legacy options {schema}', () => {
+
+		const schema = {
+			tableA: {}
+		};
+		const dare = new Dare({
+			schema
+		});
+		expect(dare.options).to.have.property('schema', schema);
+
+		// But should still construct a model
+		expect(dare.options)
+			.to.have.property('models')
+			.to.deep.eql({'tableA': {schema: {}}});
+
+	});
+
 	it('should export the DareError object', () => {
 
 		expect(Dare.DareError).to.eql(DareError);

--- a/test/specs/join_handler.js
+++ b/test/specs/join_handler.js
@@ -25,10 +25,10 @@ describe('join_handler', () => {
 
 		// Given a relationship between
 		dare.options = {
-			schema: {
+			models: {
 				parent: {},
 				child: {
-					parent_id: 'parent.id'
+					schema: {parent_id: 'parent.id'}
 				}
 			}
 		};
@@ -62,10 +62,10 @@ describe('join_handler', () => {
 
 		// Given a relationship between
 		dare.options = {
-			schema: {
+			models: {
 				parent: {},
 				child: {
-					parent_id: 'parent.id'
+					schema: {parent_id: 'parent.id'}
 				}
 			}
 		};
@@ -99,13 +99,13 @@ describe('join_handler', () => {
 
 		// Given a relationship between
 		dare.options = {
-			schema: {
+			models: {
 				grandparent: {},
 				parent: {
-					grand_id: 'grandparent.gid'
+					schema: {grand_id: 'grandparent.gid'}
 				},
 				child: {
-					parent_id: 'parent.id'
+					schema: {parent_id: 'parent.id'}
 				}
 			}
 		};
@@ -146,11 +146,13 @@ describe('join_handler', () => {
 			 * Table
 			 */
 			dare.options = {
-				schema: {
+				models: {
 
 					message: {
-						from_id: 'author.id',
-						to_id: 'recipient.id'
+						schema: {
+							from_id: 'author.id',
+							to_id: 'recipient.id'
+						}
 					},
 
 					person: {},
@@ -314,9 +316,11 @@ describe('join_handler', () => {
 
 		it('messageB.recipient: using unreferenced aliases', () => {
 
-			dare.options.schema.messageB = {
-				to_id: 'person.id',
-				from_id: 'author.id'
+			dare.options.models.messageB = {
+				schema: {
+					to_id: 'person.id',
+					from_id: 'author.id'
+				}
 			};
 
 			const recipient = {
@@ -345,9 +349,11 @@ describe('join_handler', () => {
 
 		it('recipient.messageB: using unreferenced aliases', () => {
 
-			dare.options.schema.message = {
-				from_id: 'author.id',
-				to_id: 'person.id'
+			dare.options.models.message = {
+				schema: {
+					from_id: 'author.id',
+					to_id: 'person.id'
+				}
 			};
 
 			const join_object = {
@@ -380,7 +386,7 @@ describe('join_handler', () => {
 			 * We already know from options.table_alias this is the same as a person
 			 * Redefine
 			 */
-			delete dare.options.schema.recipient;
+			delete dare.options.models.recipient;
 
 
 			const recipient = {

--- a/test/specs/patch.js
+++ b/test/specs/patch.js
@@ -142,10 +142,12 @@ describe('patch', () => {
 			beforeEach(() => {
 
 				dare.options = {
-					schema: {
+					models: {
 						'test': {
-							meta: {
-								type: 'json'
+							schema: {
+								meta: {
+									type: 'json'
+								}
 							}
 						}
 					}

--- a/test/specs/patch.js
+++ b/test/specs/patch.js
@@ -141,13 +141,11 @@ describe('patch', () => {
 
 			beforeEach(() => {
 
-				dare.options = {
-					models: {
-						'test': {
-							schema: {
-								meta: {
-									type: 'json'
-								}
+				dare.options.models = {
+					'test': {
+						schema: {
+							meta: {
+								type: 'json'
 							}
 						}
 					}
@@ -297,9 +295,9 @@ describe('patch', () => {
 
 		};
 
-		dare.options = {
-			patch: {
-				'tbl': req => {
+		dare.options.models = {
+			tbl: {
+				patch(req) {
 
 					// Augment the request
 					req.body.name = newName;
@@ -330,9 +328,9 @@ describe('patch', () => {
 
 		};
 
-		dare.options = {
-			patch: {
-				'default': async req => {
+		dare.options.models = {
+			default: {
+				async patch(req) {
 
 					req.body.name = newName;
 
@@ -353,9 +351,9 @@ describe('patch', () => {
 
 		const msg = 'snap';
 
-		dare.options = {
-			patch: {
-				'default': () => {
+		dare.options.models = {
+			default: {
+				patch() {
 
 					// Augment the request
 					throw new Error(msg);
@@ -379,9 +377,9 @@ describe('patch', () => {
 
 		const skip = 'true';
 
-		dare.options = {
-			patch: {
-				default(opts) {
+		dare.options.models = {
+			default: {
+				patch(opts) {
 
 					opts.skip = skip;
 
@@ -390,6 +388,32 @@ describe('patch', () => {
 		};
 
 		const resp = await dare
+			.patch({
+				table: 'tbl',
+				filter: {id},
+				body: {name}
+			});
+
+
+		expect(resp).to.eql(skip);
+
+	});
+
+	it('legacy: should support default patch()', async () => {
+
+		const skip = 'true';
+
+		const dare2 = dare.use({
+			patch: {
+				default(opts) {
+
+					opts.skip = skip;
+
+				}
+			}
+		});
+
+		const resp = await dare2
 			.patch({
 				table: 'tbl',
 				filter: {id},

--- a/test/specs/post.js
+++ b/test/specs/post.js
@@ -154,9 +154,9 @@ describe('post', () => {
 
 		};
 
-		dare.options = {
-			post: {
-				'tbl': req => {
+		dare.options.models = {
+			tbl: {
+				post(req) {
 
 					// Augment the request
 					req.body.name = 'andrew';
@@ -184,9 +184,9 @@ describe('post', () => {
 
 		};
 
-		dare.options = {
-			post: {
-				'default': async req => {
+		dare.options.models = {
+			default: {
+				async post(req) {
 
 					// Augment the request
 					req.body.name = 'andrew';
@@ -207,9 +207,9 @@ describe('post', () => {
 
 		const msg = 'snap';
 
-		dare.options = {
-			post: {
-				'default': () => {
+		dare.options.models = {
+			default: {
+				post() {
 
 					// Augment the request
 					throw new Error(msg);
@@ -232,9 +232,9 @@ describe('post', () => {
 
 		const skip = 'true';
 
-		dare.options = {
-			post: {
-				default(opts) {
+		dare.options.models = {
+			default: {
+				post(opts) {
 
 					opts.skip = skip;
 
@@ -243,6 +243,30 @@ describe('post', () => {
 		};
 
 		const resp = await dare
+			.post({
+				table: 'tbl',
+				body: {name: 'name'}
+			});
+
+		expect(resp).to.eql(skip);
+
+	});
+
+	it('legacy: options.schema, not exectute if the opts.skip request is marked', async () => {
+
+		const skip = 'true';
+
+		const dare2 = dare.use({
+			post: {
+				default(opts) {
+
+					opts.skip = skip;
+
+				}
+			}
+		});
+
+		const resp = await dare2
 			.post({
 				table: 'tbl',
 				body: {name: 'name'}

--- a/test/specs/post.js
+++ b/test/specs/post.js
@@ -298,10 +298,12 @@ describe('post', () => {
 			it(`type=json: should accept object, given ${JSON.stringify(given)}`, async () => {
 
 				dare.options = {
-					schema: {
+					models: {
 						'test': {
-							meta: {
-								type: 'json'
+							schema: {
+								meta: {
+									type: 'json'
+								}
 							}
 						}
 					}

--- a/test/specs/schema_override.js
+++ b/test/specs/schema_override.js
@@ -7,10 +7,12 @@ describe('schema override', () => {
 	beforeEach(() => {
 
 		dare = new Dare({
-			schema: {
+			models: {
 				users: {
-					write_protected_field: {
-						writeable: false
+					schema: {
+						write_protected_field: {
+							writeable: false
+						}
 					}
 				}
 			}
@@ -42,10 +44,12 @@ describe('schema override', () => {
 
 			const callAfterOverride = dare.patch({
 				...patchOptions,
-				schema: {
+				models: {
 					users: {
-						write_protected_field: {
-							writeable: true
+						schema: {
+							write_protected_field: {
+								writeable: true
+							}
 						}
 					}
 				}
@@ -75,10 +79,12 @@ describe('schema override', () => {
 
 			const callAfterOverride = dare.post({
 				...postOptions,
-				schema: {
+				models: {
 					users: {
-						write_protected_field: {
-							writeable: true
+						schema: {
+							write_protected_field: {
+								writeable: true
+							}
 						}
 					}
 				}


### PR DESCRIPTION
This deprecates the `options.schema`, `options.table_alias`, `options[get|post|patch|delete]` handlers

And shifts these definitions. So they are logically grouped around a model.

```js
const myModelA = {
	table, // this defines a mapping of a model to a SQL DB Table.
	schema, // A schema object defining fields, as with options.schema, the schema is now grouped in with the model.
	get, // Function to modify the request when accessing data
	post, // Function to modify the request when posting data
	patch, // Function to modify the request when patching data
	del, // Function to modify the request when deleting data
};

dare.use({
	models: {
		myModelA,
		// ... other model objects
	}
});
```
