### PR TITLE
fix(del, patch): throws an error is nested filter given, #187

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -286,6 +286,12 @@ Dare.prototype.patch = async function patch(table, filter, body, opts = {}) {
 
 	}
 
+	/*
+	 * Disallow joins
+	 * @todo: support joins see #187
+	 */
+	disallowJoins(req);
+
 	// Validate Body
 	validateBody(req.body);
 
@@ -493,6 +499,12 @@ Dare.prototype.del = async function del(table, filter, opts = {}) {
 		return _this.after(req.skip);
 
 	}
+
+	/*
+	 * Disallow joins
+	 * @todo: support joins see #187
+	 */
+	disallowJoins(req);
 
 	// Clone object before formatting
 	const a = [];
@@ -727,6 +739,22 @@ function migrateToModels(options) {
 			});
 
 		}
+
+	}
+
+}
+
+
+/**
+ * DisallowJoins
+ * @param {object} req - Formatted request object
+ * @returns {void} Checks whether a join is included in the request
+ */
+function disallowJoins(req) {
+
+	if (req._joins) {
+
+		throw new DareError(DareError.INVALID_REQUEST, `${req.method} cannot contain nested joins`);
 
 	}
 

--- a/test/specs/delete.js
+++ b/test/specs/delete.js
@@ -219,4 +219,33 @@ describe('del', () => {
 
 	});
 
+
+	it('disallow nested filters: should throw an exception', () => {
+
+		dare.options.models = {
+			tbl: {
+				schema: {
+					// Create a reference to tblB
+					ref_id: 'tblB.id'
+				}
+			}
+		};
+
+		const test = dare
+			.del({
+				table: 'tbl',
+				filter: {
+					id: 1,
+					tblB: {
+						id: 1
+					}
+				}
+			});
+
+		return expect(test)
+			.to.be.eventually.rejectedWith(DareError)
+			.and.have.property('code', DareError.INVALID_REQUEST);
+
+	});
+
 });

--- a/test/specs/patch.js
+++ b/test/specs/patch.js
@@ -4,6 +4,7 @@ const Dare = require('../../src/');
 const sqlEqual = require('../lib/sql-equal');
 
 const DareError = require('../../src/utils/error');
+const {expect} = require('chai');
 
 const id = 1;
 const name = 'name';
@@ -443,6 +444,36 @@ describe('patch', () => {
 				body: {name: 'andrew'}
 			});
 
+
+	});
+
+
+	it('disallow nested filters: should throw an exception', () => {
+
+		dare.options.models = {
+			tbl: {
+				schema: {
+					// Create a reference to tblB
+					ref_id: 'tblB.id'
+				}
+			}
+		};
+
+		const test = dare
+			.patch({
+				table: 'tbl',
+				filter: {
+					id: 1,
+					tblB: {
+						id: 1
+					}
+				},
+				body: {name: 'andrew'}
+			});
+
+		return expect(test)
+			.to.be.eventually.rejectedWith(DareError)
+			.and.have.property('code', DareError.INVALID_REQUEST);
 
 	});
 


### PR DESCRIPTION
#187

Temporarily ensure that deletes and patches do not use the unsupported nesting filters, otherwise this could lead to misleading actions.

