### PR TITLE
feat: refactor internal SQL function arguments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,6 @@ executors:
       # volumes and networking, so using a real VM is the easiest option:
       # https://circleci.com/docs/2.0/docker-compose/#using-docker-compose-with-docker-executor
       image: ubuntu-1604:202007-01
-      docker_layer_caching: true
 
 
 ################################

--- a/src/get.js
+++ b/src/get.js
@@ -24,7 +24,7 @@ module.exports = async function(opts) {
 	const {sql, values} = this.buildQuery(opts);
 
 	// Execute the query
-	const sql_response = await this.sql(sql, values);
+	const sql_response = await this.sql({sql, values});
 
 	// Format the response
 	const resp = await this.response_handler(sql_response);

--- a/test/specs/field_alias.spec.js
+++ b/test/specs/field_alias.spec.js
@@ -32,12 +32,12 @@ describe('field alias', () => {
 
 		it('should map field aliases defined in the schema into SELECT requests Fields and Filters', async () => {
 
-			let sql;
+			let _sql;
 
 			// Stub the execute function
-			dare.sql = _sql => {
+			dare.sql = ({sql}) => {
 
-				sql = _sql;
+				_sql = sql;
 				return [];
 
 			};
@@ -79,26 +79,26 @@ describe('field alias', () => {
 				limit
 			});
 
-			expect(sql).to.contain('email AS \'emailAddress\'');
-			expect(sql).to.contain('email AS \'field\'');
-			expect(sql).to.contain('LOWER(a.email) AS \'emailaddress\'');
-			expect(sql).to.contain(',a.country_id');
-			expect(sql).to.contain('email LIKE ?');
-			expect(sql).to.contain('country_id = ?');
-			expect(sql).to.contain('email IS NOT NULL');
-			expect(sql).to.contain('country_id IS NOT NULL');
+			expect(_sql).to.contain('email AS \'emailAddress\'');
+			expect(_sql).to.contain('email AS \'field\'');
+			expect(_sql).to.contain('LOWER(a.email) AS \'emailaddress\'');
+			expect(_sql).to.contain(',a.country_id');
+			expect(_sql).to.contain('email LIKE ?');
+			expect(_sql).to.contain('country_id = ?');
+			expect(_sql).to.contain('email IS NOT NULL');
+			expect(_sql).to.contain('country_id IS NOT NULL');
 
 
 		});
 
 		it('cross table alias referencing', async () => {
 
-			let sql;
+			let _sql;
 
 			// Stub the execute function
-			dare.sql = _sql => {
+			dare.sql = ({sql}) => {
 
-				sql = _sql;
+				_sql = sql;
 				return [];
 
 			};
@@ -144,15 +144,15 @@ describe('field alias', () => {
 				limit
 			});
 
-			expect(sql).to.contain('email AS \'Email Field\'');
-			expect(sql).to.contain('email AS \'Email Alias\'');
-			expect(sql).to.contain('LOWER(b.email) AS \'email_field\'');
-			expect(sql).to.contain('LOWER(b.email) AS \'email_alias\'');
+			expect(_sql).to.contain('email AS \'Email Field\'');
+			expect(_sql).to.contain('email AS \'Email Alias\'');
+			expect(_sql).to.contain('LOWER(b.email) AS \'email_field\'');
+			expect(_sql).to.contain('LOWER(b.email) AS \'email_alias\'');
 
-			expect(sql).to.contain('email LIKE ?');
-			expect(sql).to.contain('country_id = ?');
-			expect(sql).to.contain('email IS NOT NULL');
-			expect(sql).to.contain('country_id IS NOT NULL');
+			expect(_sql).to.contain('email LIKE ?');
+			expect(_sql).to.contain('country_id = ?');
+			expect(_sql).to.contain('email IS NOT NULL');
+			expect(_sql).to.contain('country_id IS NOT NULL');
 
 
 		});
@@ -164,12 +164,12 @@ describe('field alias', () => {
 
 		it('should map field aliases defined in the schema into UPDATE filters', async () => {
 
-			let sql;
+			let _sql;
 
 			// Stub the execute function
-			dare.sql = _sql => {
+			dare.sql = ({sql}) => {
 
-				sql = _sql;
+				_sql = sql;
 				return [];
 
 			};
@@ -189,9 +189,9 @@ describe('field alias', () => {
 				}
 			});
 
-			expect(sql).to.contain('`email` = ?');
-			expect(sql).to.contain('`country_id` = ?');
-			expect(sql).to.contain('email LIKE ?');
+			expect(_sql).to.contain('`email` = ?');
+			expect(_sql).to.contain('`country_id` = ?');
+			expect(_sql).to.contain('email LIKE ?');
 
 		});
 
@@ -201,12 +201,12 @@ describe('field alias', () => {
 
 		it('should map field aliases defined in the schema into DELETE filters', async () => {
 
-			let sql;
+			let _sql;
 
 			// Stub the execute function
-			dare.sql = _sql => {
+			dare.sql = ({sql}) => {
 
-				sql = _sql;
+				_sql = sql;
 				return [];
 
 			};
@@ -222,9 +222,9 @@ describe('field alias', () => {
 				}
 			});
 
-			expect(sql).to.contain('email LIKE ?');
+			expect(_sql).to.contain('email LIKE ?');
 
-			expect(sql).to.contain('country_id = ?');
+			expect(_sql).to.contain('country_id = ?');
 
 		});
 
@@ -235,12 +235,12 @@ describe('field alias', () => {
 
 		it('should map field aliases defined in the schema into INSERT body', async () => {
 
-			let sql;
+			let _sql;
 
 			// Stub the execute function
-			dare.sql = _sql => {
+			dare.sql = ({sql}) => {
 
-				sql = _sql;
+				_sql = sql;
 				return [];
 
 			};
@@ -257,11 +257,11 @@ describe('field alias', () => {
 				duplicate_keys_update: ['emailAddress', 'country_id']
 			});
 
-			expect(sql).to.contain('(`email`,`country_id`)');
+			expect(_sql).to.contain('(`email`,`country_id`)');
 
 			// ON DUPLICATE KEY UPDATE
-			expect(sql).to.contain('email=VALUES(email)');
-			expect(sql).to.contain('country_id=VALUES(country_id)');
+			expect(_sql).to.contain('email=VALUES(email)');
+			expect(_sql).to.contain('country_id=VALUES(country_id)');
 
 
 		});

--- a/test/specs/get-join.spec.js
+++ b/test/specs/get-join.spec.js
@@ -46,7 +46,7 @@ describe('get - request object', () => {
 
 	it('should generate a SELECT statement and execute dare.sql', async () => {
 
-		dare.sql = sql => {
+		dare.sql = ({sql}) => {
 
 			const expected = `
 
@@ -173,11 +173,11 @@ describe('get - request object', () => {
 
 		it('should allow multiple definitions of the same thing', async () => {
 
-			dare.sql = async query => {
+			dare.sql = async ({sql}) => {
 
 				const key = 'email1,users_email.email,users_email.emailnest';
 
-				expect(query).to.contain(key);
+				expect(sql).to.contain(key);
 
 				return [{
 					[key]: '["a@b.com","a@b.com","a@b.com"]'
@@ -230,12 +230,12 @@ describe('get - request object', () => {
 
 				it(`valid: ${JSON.stringify(value)}`, async () => {
 
-					dare.sql = (sql, prepared) => {
+					dare.sql = ({sql, values}) => {
 
 						walk(value, (value, key) => {
 
 							expect(sql).to.contain(key);
-							expect(prepared).to.contain(value);
+							expect(values).to.contain(value);
 
 						});
 
@@ -258,12 +258,12 @@ describe('get - request object', () => {
 
 			it('valid: shorthand nested filter keys', async () => {
 
-				dare.sql = (sql, prepared) => {
+				dare.sql = ({sql, values}) => {
 
 					expect(sql).to.contain('.type = ?');
 					expect(sql).to.contain('.name != ?');
-					expect(prepared).to.contain('mobile');
-					expect(prepared).to.contain('me');
+					expect(values).to.contain('mobile');
+					expect(values).to.contain('me');
 
 					return Promise.resolve([]);
 
@@ -285,7 +285,7 @@ describe('get - request object', () => {
 
 			it('should negate nested conditions', async () => {
 
-				dare.sql = (sql, prepared) => {
+				dare.sql = ({sql, values}) => {
 
 					expectSQLEqual(sql, `
 						SELECT a.id FROM activityEvents a
@@ -299,7 +299,7 @@ describe('get - request object', () => {
 							)
 						LIMIT 5`);
 
-					expect(prepared).to.deep.equal([1, 3, 2]);
+					expect(values).to.deep.equal([1, 3, 2]);
 
 					return Promise.resolve([]);
 
@@ -390,7 +390,7 @@ describe('get - request object', () => {
 
 				it(`valid: ${JSON.stringify(test.join)}`, async () => {
 
-					dare.sql = sql => {
+					dare.sql = ({sql}) => {
 
 						expectSQLEqual(sql, expected);
 
@@ -413,7 +413,7 @@ describe('get - request object', () => {
 
 		it('should ignore redundant joins', async () => {
 
-			dare.sql = sql => {
+			dare.sql = ({sql}) => {
 
 				const expected = `
 					SELECT a.id
@@ -449,7 +449,7 @@ describe('get - request object', () => {
 
 		it('should enforce required table joins', async () => {
 
-			dare.sql = sql => {
+			dare.sql = ({sql}) => {
 
 				const expected = `
 					SELECT a.id, b.name AS 'asset.name'
@@ -483,7 +483,7 @@ describe('get - request object', () => {
 
 		it('should enforce required table joins between deep nested tables', async () => {
 
-			dare.sql = sql => {
+			dare.sql = ({sql}) => {
 
 				const expected = `
 					SELECT a.id, b.name AS 'asset.name'
@@ -526,7 +526,7 @@ describe('get - request object', () => {
 
 		it('should automatically assign a GROUP BY on a 1:n join', async () => {
 
-			dare.sql = sql => {
+			dare.sql = ({sql}) => {
 
 				const expected = `
 					SELECT a.id
@@ -558,7 +558,7 @@ describe('get - request object', () => {
 
 		it('should not automatically assign a GROUP on an 1:n join where there are Aggregate ', async () => {
 
-			dare.sql = sql => {
+			dare.sql = ({sql}) => {
 
 				const expected = `
 					SELECT COUNT(*) AS '_count'

--- a/test/specs/get-sort-group.spec.js
+++ b/test/specs/get-sort-group.spec.js
@@ -30,7 +30,7 @@ const limit = 5;
 
 		it('should add orderby using nested tables', async () => {
 
-			dare.sql = async sql => {
+			dare.sql = async ({sql}) => {
 
 				const expected = `
 					SELECT a.email, b.name AS 'name'
@@ -58,7 +58,7 @@ const limit = 5;
 
 		it('should use the field label', async () => {
 
-			dare.sql = async sql => {
+			dare.sql = async ({sql}) => {
 
 				const expected = `
 					SELECT a.email, DATE(c.created) AS 'users.country.date', c.name AS 'CountryName'
@@ -100,7 +100,7 @@ const limit = 5;
 
 		it('should join on tables which do not return fields', async () => {
 
-			dare.sql = async sql => {
+			dare.sql = async ({sql}) => {
 
 				const expected = `
 					SELECT a.email

--- a/test/specs/get-subquery.spec.js
+++ b/test/specs/get-subquery.spec.js
@@ -43,7 +43,7 @@ describe('get - subquery', () => {
 
 	it('should write one to many requests with a subquery', async () => {
 
-		dare.sql = sql => {
+		dare.sql = ({sql}) => {
 
 			const expected = `
 
@@ -85,7 +85,7 @@ describe('get - subquery', () => {
 
 	it('should export the response in the format given', async () => {
 
-		dare.sql = sql => {
+		dare.sql = ({sql}) => {
 
 			const expected = `
 
@@ -128,7 +128,7 @@ describe('get - subquery', () => {
 
 	it('should concatinate many expressions into an array using GROUP_CONCAT', async () => {
 
-		dare.sql = sql => {
+		dare.sql = ({sql}) => {
 
 			const expected = `
 
@@ -170,7 +170,7 @@ describe('get - subquery', () => {
 
 	it('should *not* subquery a nested object without fields', async () => {
 
-		dare.sql = sql => {
+		dare.sql = ({sql}) => {
 
 			const expected = `
 
@@ -205,7 +205,7 @@ describe('get - subquery', () => {
 
 	it('should *not* use a subquery when the many table is used in the filter', async () => {
 
-		dare.sql = sql => {
+		dare.sql = ({sql}) => {
 
 			const expected = `
 				SELECT a.name AS 'name',
@@ -241,7 +241,7 @@ describe('get - subquery', () => {
 
 	it('should *not* subquery a table off a join with a possible set of values', async () => {
 
-		dare.sql = sql => {
+		dare.sql = ({sql}) => {
 
 			const expected = `
 				SELECT a.name AS 'name', CONCAT('[',GROUP_CONCAT(CONCAT_WS('', '[', '"', REPLACE(REPLACE(COUNT(d.id), '\\\\', '\\\\\\\\'), '"','\\\\"'),'"',']')),']') AS 'assetCollections[collections.descendents]'
@@ -282,7 +282,7 @@ describe('get - subquery', () => {
 	it('should aggregate single field requests in a subquery, aka without group_concat', async () => {
 
 
-		dare.sql = sql => {
+		dare.sql = ({sql}) => {
 
 			const expected = `
 				SELECT a.id,a.name,a.created_time,
@@ -335,7 +335,7 @@ describe('get - subquery', () => {
 
 		it('should allow multiple groupby on nested tables', async () => {
 
-			dare.sql = async sql => {
+			dare.sql = async ({sql}) => {
 
 				expect(sql).to.contain('GROUP BY c.id,a.id');
 

--- a/test/specs/init.spec.js
+++ b/test/specs/init.spec.js
@@ -49,7 +49,7 @@ describe('Dare', () => {
 		const dare = new Dare();
 
 		const test = dare
-			.sql('SELECT 1=1');
+			.sql({sql: 'SELECT 1=1'});
 
 		return expect(test)
 			.to.be.eventually.rejectedWith(DareError, 'Define dare.execute to continue');

--- a/test/specs/sql.spec.js
+++ b/test/specs/sql.spec.js
@@ -26,7 +26,7 @@ describe('sql', () => {
 
 	});
 
-	it('should trigger execute from a string', async () => {
+	it('deprecated: should trigger execute from a string', async () => {
 
 		const res = await dare.sql(query, values);
 		expect(res).to.eql(values[0]);
@@ -50,7 +50,7 @@ describe('sql', () => {
 
 		};
 
-		const test = dare.sql(query);
+		const test = dare.sql({sql: query});
 
 		return expect(test)
 			.to.be.eventually.rejectedWith(Error, msg);


### PR DESCRIPTION
Internally use `dare.sql({sql, values})` pattern

This could likely disrupt implementation tests where `dare.sql = overwritingFunction` is invoked