### PR TITLE
fix(duplicate_keys_update): put backticks around UPDATE fields

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -630,7 +630,7 @@ function mustAffectRows(result, notfound) {
 
 function onDuplicateKeysUpdate(keys = []) {
 
-	const s = keys.map(name => `${name}=VALUES(${name})`).join(',');
+	const s = keys.map(name => `\`${name}\`=VALUES(\`${name}\`)`).join(',');
 
 	return `ON DUPLICATE KEY UPDATE ${s}`;
 

--- a/test/integration/get.spec.js
+++ b/test/integration/get.spec.js
@@ -73,6 +73,20 @@ const schema = {
 
 		});
 
+		it('Can update results with INSERT...ON DUPLICATE KEYS UPDATE', async () => {
+
+			const username = 'A Name';
+			const newName = 'New name';
+			const {insertId} = await dare.post('users', {username});
+			await dare.post('users', {id: insertId, username: newName}, {
+				duplicate_keys_update: ['username']
+			});
+
+			const resp = await dare.get('users', ['username']);
+
+			expect(resp).to.have.property('username', newName);
+
+		});
 
 		it('should be able to return nested values', async () => {
 

--- a/test/specs/field_alias.spec.js
+++ b/test/specs/field_alias.spec.js
@@ -260,8 +260,8 @@ describe('field alias', () => {
 			expect(_sql).to.contain('(`email`,`country_id`)');
 
 			// ON DUPLICATE KEY UPDATE
-			expect(_sql).to.contain('email=VALUES(email)');
-			expect(_sql).to.contain('country_id=VALUES(country_id)');
+			expect(_sql).to.contain('`email`=VALUES(`email`)');
+			expect(_sql).to.contain('`country_id`=VALUES(`country_id`)');
 
 
 		});

--- a/test/specs/post.spec.js
+++ b/test/specs/post.spec.js
@@ -111,7 +111,7 @@ describe('post', () => {
 		dare.execute = async ({sql, values}) => {
 
 			called = 1;
-			sqlEqual(sql, 'INSERT INTO test (`id`, `name`, `age`) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE name=VALUES(name), age=VALUES(age)');
+			sqlEqual(sql, 'INSERT INTO test (`id`, `name`, `age`) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE `name`=VALUES(`name`), `age`=VALUES(`age`)');
 			expect(values).to.deep.equal([1, 'name', 38]);
 			return {};
 


### PR DESCRIPTION
Puts backticks (<code>`</code>) around field names when using the `duplicate_keys_update` option.

```sql
INSERT INTO ... ON DUPLICATE KEY UPDATE `name`=VALUES(`name`), `age`=VALUES(`age`)
```

Previously
```sql
INSERT INTO ... ON DUPLICATE KEY UPDATE name=VALUES(name), age=VALUES(age)
```
