### PR TITLE
docs(field_expressions): add caveat around multiple columns in field_expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1236,3 +1236,21 @@ await dare.patch({
 	},
 });
 ```
+
+
+# Caveats
+
+## Only one column name may appear in a Field Expression
+
+Dare can't have more than one model field/column names in the same field expression.
+
+e.g. Fields array....
+```js
+[{
+	// Both fist_name and last_name in the same field expression 💥
+	`displayName`: 'CONCAT(first_name, last_name)' // ❌
+}]
+```
+
+To work around this we'd simply use post-formatting. Either write one yourself or make a Generated Field (handler) in the Dare schema and request that by name in the field expression.
+

--- a/test/specs/unwrap_field.spec.js
+++ b/test/specs/unwrap_field.spec.js
@@ -8,7 +8,10 @@ import DareError from '../../src/utils/error.js';
 
 describe('utils/unwrap_field', () => {
 
-	// Should unwrap SQL Formating to underlying column name
+	/*
+	 * Supported Field Expressions
+	 * Should unwrap SQL Formating to underlying column name
+	 */
 	[
 		'field',
 		'DATE(field)',
@@ -55,22 +58,39 @@ describe('utils/unwrap_field', () => {
 
 	});
 
-	// Should unwrap SQL Formating to underlying column name
+
+	/*
+	 * Unsupported field expressions
+	 * Shall throw an error when unwrapping SQL these field expressions.
+	 * Either the syntax errors or unsupported SQL in Dare.
+	 */
 	[
+		// Bad Syntax
 		'field(',
-		'CONCAT(field, secret)',
-		'IF(field < field2, "yes", "no")',
-		'IF(field IS NOT NULL, "yes", "no")',
 		'IF(field < "string"str, "yes", "no")',
 		'IF(field = \'string", "yes", "no")',
+		'DATE_FORMAT(field, ',
 		'IF(field <<< 123, "yes", "no")',
+
+		/*
+		 * VALID SYNTAX, BUT UNSUPPORTED
+		 */
+
+		// IS NOT NULL
+		'IF(field IS NOT NULL, "yes", "no")',
+
+		// Bad spacing
 		'IF(field<123, "yes", "no")',
-		'DATE_FORMAT(field, '
+
+		// More than 1 field requested
+		'CONCAT(field, secret)',
+		'IF(field < field2, "yes", "no")'
+
 	].forEach(test => {
 
 		it(`errors: ${JSON.stringify(test)}`, () => {
 
-			// Expect the formatted list of fields to be identical to the inputted value
+			// Expect the field expression unwrapping to throw a Dare Error
 			expect(unwrap_field.bind(null, test)).to.throw(DareError);
 
 		});


### PR DESCRIPTION
#239

Documents the current caveat around multiple column references in field expressions.