### PR TITLE
feat(insert-select): create an INSERT...SELECT statement, #245

### DIFF
--- a/src/get.js
+++ b/src/get.js
@@ -6,7 +6,7 @@ import field_format from './utils/field_format.js';
 import orderbyUnwrap from './utils/orderby_unwrap.js';
 
 
-export default async function(opts) {
+export default function(opts) {
 
 	// Reset the alias
 	this.unique_alias_index = 0;
@@ -21,33 +21,7 @@ export default async function(opts) {
 	this.traverse = traverse;
 
 	// Execute the Build
-	const {sql, values} = this.buildQuery(opts);
-
-	// Execute the query
-	const sql_response = await this.sql({sql, values});
-
-	// Format the response
-	const resp = await this.response_handler(sql_response);
-
-	// If limit was not defined we should return the first result only.
-	if (opts.single) {
-
-		if (resp.length) {
-
-			return resp[0];
-
-		}
-		else if (typeof opts.notfound === 'function') {
-
-			opts.notfound();
-
-		}
-
-		return opts.notfound;
-
-	}
-
-	return resp;
+	return this.buildQuery(opts);
 
 }
 

--- a/test/specs/post_query.spec.js
+++ b/test/specs/post_query.spec.js
@@ -1,0 +1,61 @@
+import Dare from '../../src/index.js';
+
+// Test Generic DB functions
+import sqlEqual from '../lib/sql-equal.js';
+
+describe('post from query', () => {
+
+	let dare;
+
+	beforeEach(() => {
+
+		dare = new Dare();
+
+		// Should not be called...
+		dare.execute = () => {
+
+			throw new Error('execute called');
+
+		};
+
+	});
+
+
+	it('should generate an INSERT...SELECT statement and execute dare.execute', async () => {
+
+		dare.execute = async ({sql, values}) => {
+
+			sqlEqual(sql, `
+				INSERT INTO test (\`origin_id\`, \`name\`)
+				SELECT a.id AS 'origin_id', a.name
+				FROM origin a
+				WHERE a.name = ?
+				LIMIT 1000
+				ON DUPLICATE KEY UPDATE _rowid=_rowid
+			`);
+			expect(values).to.deep.equal(['Liz']);
+			return {id: 1};
+
+		};
+
+		const resp = await dare
+			.post({
+				table: 'test',
+				query: {
+					table: 'origin',
+					fields: [{
+						origin_id: 'id'
+					}, 'name'],
+					filter: {
+						'name': 'Liz'
+					},
+					limit: 1000
+				},
+				duplicate_keys: 'ignore'
+			});
+
+		expect(resp).to.have.property('id', 1);
+
+	});
+
+});


### PR DESCRIPTION
Allows the creation of an insert select statement


```js
await dare.post({
    table: 'test',
    query: {
        table: 'origin',
        fields: [{
            origin_id: 'id'
        }, 'name'],
        filter: {
            'name': 'Liz'
        },
        limit: 1000
    },
    duplicate_keys: 'ignore'
});
```

Generates...

```SQL
INSERT INTO test (`origin_id`, `name`)
SELECT a.id AS 'origin_id', a.name
FROM origin a
WHERE a.name = ?
LIMIT 1000
ON DUPLICATE KEY UPDATE _rowid=_rowid
```