### PR TITLE
fix(sql): if field is null, conditional fields

### DIFF
--- a/src/utils/unwrap_field.js
+++ b/src/utils/unwrap_field.js
@@ -54,7 +54,7 @@ export default function unwrap_field(expression, formatter = (obj => obj)) {
 			/*
 			 * Deal with math and operators against a value
 			 */
-			const int_x = str.match(/(.*)(\s(\*|\/|>|<|=|<=|>=|<>|!=)\s([0-9.]+|((?<quote>["'])[a-z0-9%._\s-]*\k<quote>)))$/i);
+			const int_x = str.match(/(.*)(\s((\*|\/|>|<|=|<=|>=|<>|!=)\s([0-9.]+|((?<quote>["'])[a-z0-9%._\s-]*\k<quote>))|IS NULL|IS NOT NULL))$/i);
 
 			if (int_x) {
 
@@ -64,6 +64,7 @@ export default function unwrap_field(expression, formatter = (obj => obj)) {
 			}
 
 		}
+
 
 		// Does the string start with a negation (!) ?
 		if (str && str.startsWith('!')) {
@@ -80,6 +81,7 @@ export default function unwrap_field(expression, formatter = (obj => obj)) {
 			str = str.slice(m[0].length);
 
 		}
+
 
 		// Finally check that the str is a match
 		if (str.match(/^[a-z0-9$._*]*$/i)) {

--- a/test/specs/unwrap_field.spec.js
+++ b/test/specs/unwrap_field.spec.js
@@ -34,6 +34,8 @@ describe('utils/unwrap_field', () => {
 		'IF(field <> 1, "yes", "no")',
 		'IF(field = "string", "yes", "no")',
 		'IF(field != \'string\', "yes", "no")',
+		'IF(field IS NULL, "yes", "no")',
+		'IF(field IS NOT NULL, "yes", "no")',
 		'COALESCE(field, "")',
 		'NULLIF(field, "is null")',
 		'ROUND(field, 2)',
@@ -75,9 +77,6 @@ describe('utils/unwrap_field', () => {
 		/*
 		 * VALID SYNTAX, BUT UNSUPPORTED
 		 */
-
-		// IS NOT NULL
-		'IF(field IS NOT NULL, "yes", "no")',
 
 		// Bad spacing
 		'IF(field<123, "yes", "no")',


### PR DESCRIPTION
Supports in fields the following SQL

```js
[
		'IF(field IS NULL, "yes", "no")',
		'IF(field IS NOT NULL, "yes", "no")',
]
```