### PR TITLE
feat(fixed-field-values): i.e.  SELECT 123 AS myField... for #245

### DIFF
--- a/src/format/field_reducer.js
+++ b/src/format/field_reducer.js
@@ -26,7 +26,8 @@ export default function fieldReducer({field_alias_path, extract, table_schema, d
 			for (const key in field) {
 
 				const value = field[key];
-				if (typeof value === 'object') {
+
+				if (typeof value === 'object' && value !== null) {
 
 					// Ensure this isn't empty
 					if (isEmpty(value)) {
@@ -105,7 +106,20 @@ export default function fieldReducer({field_alias_path, extract, table_schema, d
 function fieldMapping({field, label, fieldsArray, originalArray, field_alias_path, extract, table_schema, dareInstance}) {
 
 	// Extract the underlying field
-	const {field_name, prefix, suffix, field_path, field: address} = checkFormat(field);
+	const {field_name, prefix, suffix, field_path, field: address, value} = checkFormat(field);
+
+	/**
+	 * If this is a simple value
+	 * Let's return it
+	 */
+	if (value !== undefined) {
+
+		// Return original field
+		return {
+			[label]: field
+		};
+
+	}
 
 	/*
 	 * Is this part of another table?

--- a/src/format/groupby_reducer.js
+++ b/src/format/groupby_reducer.js
@@ -8,7 +8,7 @@ export default function groupbyReducer({current_path, extract}) {
 	return mapReduce(field => {
 
 		// Get the field address
-		const item = fieldUnwrap(field);
+		const item = fieldUnwrap(field, false);
 		const address = fieldRelativePath(current_path, item.field);
 
 		// Get the parent of the field

--- a/src/format/orderby_reducer.js
+++ b/src/format/orderby_reducer.js
@@ -17,7 +17,7 @@ export default ({current_path, extract, table_schema}) => mapReduce(entry => {
 	}
 
 	// Get the field address
-	const item = fieldUnwrap(field);
+	const item = fieldUnwrap(field, false);
 
 	// Add direction
 	item.direction = direction;

--- a/src/utils/field_format.js
+++ b/src/utils/field_format.js
@@ -2,7 +2,16 @@ import unwrap_expression from './unwrap_field.js';
 
 export default function field_format(original, label, table_prefix, label_prefix) {
 
-	const {field, prefix, suffix} = unwrap_expression(original);
+	const {field, prefix, suffix, value} = unwrap_expression(original);
+
+	if (value !== undefined) {
+
+		return {
+			label,
+			expression: value
+		};
+
+	}
 
 	// Split it...
 	const a = field.split('.');

--- a/src/utils/unwrap_field.js
+++ b/src/utils/unwrap_field.js
@@ -2,7 +2,7 @@
 /* eslint-disable prefer-named-capture-group */
 import DareError from './error.js';
 
-export default function unwrap_field(expression, formatter = (obj => obj)) {
+export default function unwrap_field(expression, allowValue = true) {
 
 	if (typeof expression === 'string') {
 
@@ -82,7 +82,6 @@ export default function unwrap_field(expression, formatter = (obj => obj)) {
 
 		}
 
-
 		// Finally check that the str is a match
 		if (str.match(/^[a-z0-9$._*]*$/i)) {
 
@@ -91,16 +90,40 @@ export default function unwrap_field(expression, formatter = (obj => obj)) {
 			const field_name = a.pop();
 			const field_path = a.join('.');
 
-			// This passes the test
-			return formatter({
+			const resp = {
 				field,
 				field_name,
 				field_path,
 				prefix,
 				suffix
-			});
+			};
+
+			// This passes the test
+			return resp;
 
 		}
+
+		// Return value...
+		if (allowValue) {
+
+			if (str.length === 0 || /^(["'])[\w\s]+\1$/.test(str)) {
+
+				return {
+					value: expression
+				};
+
+			}
+
+		}
+
+	}
+
+	// Else if this is not a reference to a db field, pass as a value
+	else if (allowValue && typeof expression === 'number' || expression === null || typeof expression === 'boolean') {
+
+		return {
+			value: expression
+		};
 
 	}
 

--- a/test/specs/format_request.spec.js
+++ b/test/specs/format_request.spec.js
@@ -92,7 +92,7 @@ describe('format_request', () => {
 
 		});
 
-		describe('should accept', () => {
+		describe('should accept fields', () => {
 
 			[
 				['field'],
@@ -103,7 +103,9 @@ describe('format_request', () => {
 				[{'asset': 'DATE(field)'}],
 				[{'My Fields - and &*^@:£@$ things...': 'DATE(field)'}],
 				[{'asset': 'GROUP_CONCAT(DISTINCT field)'}],
-				{'asset': ['field']}
+				{'asset': ['field']},
+				{'bespoke': 100},
+				{'bespoke': null}
 			].forEach(fields => {
 
 				it(`valid: ${JSON.stringify(fields)}`, async () => dare.format_request({...options, fields}));

--- a/test/specs/get.spec.js
+++ b/test/specs/get.spec.js
@@ -478,5 +478,49 @@ describe('get', () => {
 
 	});
 
+
+	describe('Simple return values', () => {
+
+		const basic_record = {
+			name: 'andrew'
+		};
+
+		const basic_fields = [{
+			'show_100': 100,
+			'show_null': null,
+			'show_text': '"Text string 123"',
+			'show_function_text': 'CONCAT("Hello", "World")',
+			'name': 'name'
+		}];
+
+		it('Should return numbers and null types verbatim', async () => {
+
+			dare.execute = async ({sql, values}) => {
+
+				/*
+				 * Defaults
+				 * Limit: 1
+				 * Fields: *
+				 */
+				sqlEqual(sql, `
+					SELECT 100 AS 'show_100', null AS 'show_null', "Text string 123" AS 'show_text', CONCAT("Hello", "World") AS 'show_function_text', a.name AS 'name' FROM test a WHERE a.id = ? LIMIT 1
+				`);
+				expect(values).to.deep.equal([id]);
+
+				return [basic_record];
+
+			};
+
+			const resp = await dare
+				.get('test', basic_fields, {id});
+
+
+			expect(resp).to.be.a('object');
+			expect(resp).to.eql(basic_record);
+
+		});
+
+	});
+
 });
 


### PR DESCRIPTION
For #245 

In order to support INSERT...SELECT more practically. We need to be able to insert fixed values. To do that we need the `dare.get(..{fields[]})` to provide scalar values rather that define path to a field.

E.g.
```js
const resp = await dare.get({
	table: 'test',
	fields: [{
		'show_100': 100,
		'show_null': null,
		'show_text': '"Text string 123"',
		'show_function_text': 'CONCAT("Hello", "World")',
		'name': 'name'
	}],
	filter: {id}
});

// SELECT 100 AS 'show_100', null AS 'show_null', "Text string 123" AS 'show_text', CONCAT("Hello", "World") AS 'show_function_text', a.name AS 'name' FROM test a WHERE a.id = ? LIMIT 1
```

This allows us to define non-field related result items, and wrt to INSERT...SELECT allows us to add a mix of query result data and new fields.