### PR TITLE
feat(defaultValues): support schema defaultValues in post, #249

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,9 @@
 		"plugin:node/recommended",
 		"5app"
 	],
+	"parserOptions": {
+		"ecmaVersion": "latest"
+	},
 	"plugins": [
 		"promise",
 		"security"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [14, 16, 18]
+        node_version: [16, 18]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -651,6 +651,7 @@ Property | Attr Example | Shorthand DataType | ShortHand Example | Description
 `alias` | e.g. `{alias: 'email'}` | `String` | `emailAddress: 'email'` | Alias a field with a DB Table field
 `handler` | e.g. `{handler: Function}` | `Function` | `url: urlFunction` | Generated Field
 `type` | e.g. `{type: 'json'}` | na | na | Type of data in field, this has various uses.
+`defaultValue` | e.g. `{defaultValue: 'active'}` | na | na | Default Value to insert during post, and filter with get/patch/del
 `readable` | e.g. `{readable: false}` | na | na | Disables/Enables request access to a field
 `writeable` | e.g. `{writeable: false}` | na | na | Disables/Enables write access to a field
 na | e.g. `{writeable: false: readable: false}` | `Boolean` | `{password: false}` | Disables/Enables both write and read access to a field
@@ -832,6 +833,47 @@ const dare = new Dare({
 		}
 	}
 });
+```
+
+
+#### Field attribute: `defaultValue`
+
+Defining the `defaultValue` introduces default conditions or values when querying or inserting records respectively.
+
+`defaultValue` can be any value supported by the context it is used. If `defaultValue` is not an object, it will be applied to all operations, "methods" (`get`, `post`, `patch` and `del`). However when `defaultValue` is defined as an object, then the properties of the object matching the method will be used.
+
+e.g we can define what `defaultValue` is used in various scenarios:
+
+```js
+defaultValue: {
+	get: 'active', // Includes `= 'active'` to `.get` filter conditions.
+	post: 'active', // Inserts `active` into new records
+	del: 'inactive', // Includes `= 'inactive'` to `.del` filter conditions.
+	// patch: is undefined and wont apply any default values
+}
+```
+
+**`defaultValue`**
+
+In the example we're going to set the defaultValue for the `users.status` field to `"active"`.
+
+```js
+const dare = new Dare({
+	models: {
+		users: {
+			schema: {
+				status: {
+					defaultValue: 'active'
+				}
+			}
+		}
+	}
+});
+
+// And now requests will by default include that value
+await dare.post('users', {name: 'Andrew'}); // INSERT INTO users (name, status) VALUES ("Andrew", "active")
+await dare.get('users', ['id'], {limit: 100}); // SELECT id FROM users WHERE status = 'active' LIMIT 100
+// ... adds same condition for Del and Patch methods
 ```
 
 #### Field attribute: `readable`/`writeable`

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "./utils/*": "./src/utils/*.js"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16.9"
   },
   "scripts": {
     "pretest": "npm run lint",

--- a/src/index.js
+++ b/src/index.js
@@ -441,24 +441,39 @@ Dare.prototype.post = async function post(table, body, opts = {}) {
 		 * Let's catch the omitted properties
 		 * --> Loop through the modelSchema
 		 */
-		if (validateInput) {
+		Object.entries(modelSchema).forEach(([field, fieldObject]) => {
 
-			Object.entries(modelSchema).forEach(([field, fieldObject]) => {
+			// For each property which was not covered by the input
+			if (field !== 'default' && !(field in item)) {
 
-				// For each property which was not covered by the input
-				if (field !== 'default' && !(field in item)) {
+				// Get a formatted object of field attributes
+				const fieldAttributes = getFieldAttributes(fieldObject);
 
-					// Get a formatted object of field attributes
-					const fieldAttributes = getFieldAttributes(fieldObject);
+				// Validate with an undefined value
+				validateInput?.(fieldAttributes, field);
 
-					// Validate with an undefined value
-					validateInput(fieldAttributes, field);
+				// Default values?
+				if (fieldAttributes?.defaultValue?.post) {
+
+					// Get the index in the field list
+					let i = fields.indexOf(field);
+
+					if (i === -1) {
+
+						i = fields.length;
+
+						fields.push(field);
+
+					}
+
+					// Insert the defaultValue at that position
+					_data[i] = fieldAttributes?.defaultValue?.post;
 
 				}
 
-			});
+			}
 
-		}
+		});
 
 		return _data;
 

--- a/src/utils/field_attributes.js
+++ b/src/utils/field_attributes.js
@@ -9,6 +9,24 @@ export default fieldDefinition => {
 
 	if (fieldDefinition && typeof fieldDefinition === 'object' && !Array.isArray(fieldDefinition)) {
 
+		/*
+		 * If 'defaultValue' is defined
+		 * Expand default value
+		 */
+		if (Object.hasOwn(fieldDefinition, 'defaultValue') && (fieldDefinition.defaultValue === null || typeof fieldDefinition.defaultValue !== 'object')) {
+
+			const val = fieldDefinition.defaultValue;
+
+			fieldDefinition.defaultValue = {
+				get: val,
+				post: val,
+				patch: val,
+				del: val
+			};
+
+		}
+
+
 		// This is already a definition object
 		return fieldDefinition;
 

--- a/test/specs/schema.defaultValue.spec.js
+++ b/test/specs/schema.defaultValue.spec.js
@@ -1,0 +1,125 @@
+import Dare from '../../src/index.js';
+
+import fieldAttributes from '../../src/utils/field_attributes.js';
+
+describe('schema.defaultValue', () => {
+
+	let dare;
+
+	beforeEach(() => {
+
+		// Create a new instance
+		dare = new Dare();
+
+	});
+
+	describe('fieldAttributes', () => {
+
+		it('defaultValue should not occur by default', () => {
+
+			const attr = fieldAttributes({});
+			expect(attr).to.not.have.property('defaultValue');
+
+		});
+
+		it('defaultValue object should be passed-through verbatim', () => {
+
+			const defaultValue = {
+				post: 'postValue',
+				get: 123,
+				patch: null
+			};
+
+			const attr = fieldAttributes({defaultValue});
+			expect(attr).to.have.property('defaultValue', defaultValue);
+
+		});
+
+		[undefined, 1, null, 'string'].forEach(defaultValue => {
+
+			it(`should expand defaultValue, ${defaultValue}`, () => {
+
+				const attr = fieldAttributes({defaultValue});
+				expect(attr).to.have.property('defaultValue')
+					.to.deep.equal({
+						post: defaultValue,
+						get: defaultValue,
+						patch: defaultValue,
+						del: defaultValue
+					});
+
+			});
+
+		});
+
+	});
+
+	describe('POST', () => {
+
+		beforeEach(() => {
+
+			dare = dare.use({
+				models: {
+					mytable: {
+						schema: {
+							status: {
+								defaultValue: 'active'
+							}
+						}
+					}
+				}
+			});
+
+		});
+
+		it('should insert default values into post operations', () => {
+
+			dare.execute = ({sql, values}) => {
+
+				expect(sql).to.include('`status`');
+				expect(values).to.include('active');
+
+			};
+
+			dare.post('mytable', {
+				title: 'hello'
+			});
+
+		});
+
+		it('should be overrideable', () => {
+
+			dare.execute = ({sql, values}) => {
+
+				expect(sql).to.include('`status`');
+				expect(values).to.include('overridden');
+
+			};
+
+			dare.post('mytable', {
+				title: 'hello',
+				status: 'overridden'
+			});
+
+		});
+
+		it('should be removed', () => {
+
+			dare.execute = ({sql, values}) => {
+
+				expect(sql).to.include('`status`');
+				expect(sql).to.include('DEFAULT');
+				expect(values).to.not.include(undefined);
+
+			};
+
+			dare.post('mytable', {
+				title: 'hello',
+				status: undefined
+			});
+
+		});
+
+	});
+
+});

--- a/test/specs/schema.defaultValue.spec.js
+++ b/test/specs/schema.defaultValue.spec.js
@@ -2,6 +2,19 @@ import Dare from '../../src/index.js';
 
 import fieldAttributes from '../../src/utils/field_attributes.js';
 
+function spy(obj, func, callback) {
+
+	const history = [];
+	obj[func] = (...params) => {
+
+		history.push(params);
+		return callback(...params);
+
+	};
+	return history;
+
+}
+
 describe('schema.defaultValue', () => {
 
 	let dare;
@@ -9,7 +22,19 @@ describe('schema.defaultValue', () => {
 	beforeEach(() => {
 
 		// Create a new instance
-		dare = new Dare();
+		const _dare = new Dare();
+
+		dare = _dare.use({
+			models: {
+				mytable: {
+					schema: {
+						status: {
+							defaultValue: 'active'
+						}
+					}
+				}
+			}
+		});
 
 	});
 
@@ -54,68 +79,168 @@ describe('schema.defaultValue', () => {
 
 	});
 
-	describe('POST', () => {
+	describe('formatRequest', () => {
 
-		beforeEach(() => {
+		['get', 'post', 'patch', 'del'].forEach(method => {
 
-			dare = dare.use({
-				models: {
-					mytable: {
-						schema: {
-							status: {
-								defaultValue: 'active'
-							}
-						}
-					}
-				}
+			it(`should add as a join filter in formatRequest for ${method}`, async () => {
+
+				const value = method;
+
+				// Update dare instance
+				dare.options.method = method;
+
+				// Set the default value for the method
+				dare.options.models.mytable.schema.status = {defaultValue: {[value]: value}};
+
+				const resp = await dare.format_request({
+					table: 'mytable',
+					fields: ['id', 'name']
+				});
+
+				expect(resp.join).to.have.property('status', value);
+
 			});
 
 		});
 
-		it('should insert default values into post operations', () => {
+	});
 
-			dare.execute = ({sql, values}) => {
 
-				expect(sql).to.include('`status`');
-				expect(values).to.include('active');
+	describe('POST', () => {
 
-			};
+		it('should insert default values into post operations', async () => {
 
-			dare.post('mytable', {
+			const history = spy(dare, 'execute', () => ({}));
+
+			await dare.post('mytable', {
 				title: 'hello'
 			});
 
+			const [{sql, values}] = history.at(0);
+			expect(sql).to.include('`status`');
+			expect(values).to.include('active');
+
 		});
 
-		it('should be overrideable', () => {
+		it('should be overrideable', async () => {
 
-			dare.execute = ({sql, values}) => {
+			const history = spy(dare, 'execute', () => ({}));
 
-				expect(sql).to.include('`status`');
-				expect(values).to.include('overridden');
-
-			};
-
-			dare.post('mytable', {
+			await dare.post('mytable', {
 				title: 'hello',
 				status: 'overridden'
 			});
 
+			const [{sql, values}] = history.at(0);
+			expect(sql).to.include('`status`');
+			expect(values).to.include('overridden');
+
 		});
 
-		it('should be removed', () => {
+		it('should be removed', async () => {
 
-			dare.execute = ({sql, values}) => {
+			const history = spy(dare, 'execute', () => ({}));
 
-				expect(sql).to.include('`status`');
-				expect(sql).to.include('DEFAULT');
-				expect(values).to.not.include(undefined);
-
-			};
-
-			dare.post('mytable', {
+			await dare.post('mytable', {
 				title: 'hello',
 				status: undefined
+			});
+
+			/*
+			 * TODO: Should not include filters where the values are undefined
+			 * This should be akin to removing the defaultValue too
+			 */
+			const [{sql, values}] = history.at(0);
+			expect(sql).to.include('`status`');
+			expect(sql).to.include('DEFAULT');
+			expect(values).to.not.include(undefined);
+
+
+		});
+
+	});
+
+
+	describe('DEL/GET/PATCH', () => {
+
+		['get', 'patch', 'del'].forEach(method => {
+
+			it(`should add WHERE condition for the dare.${method}() call`, async () => {
+
+				const value = method;
+
+				// Set the default value for the method
+				dare.options.models.mytable.schema.status = {defaultValue: {[method]: value}};
+
+				const history = spy(dare, 'execute', () => ([]));
+
+				await dare[method]({
+					table: 'mytable',
+					fields: ['id', 'name'],
+					body: {name: 'newvalue'},
+					notfound: null
+				});
+
+				const [{sql, values}] = history.at(0);
+
+				expect(sql).to.include('status = ');
+				expect(values).to.include(method);
+
+			});
+
+			it(`should be overideable within a dare.${method}() call`, async () => {
+
+				const value = method;
+
+				// Set the default value for the method
+				dare.options.models.mytable.schema.status = {defaultValue: {[method]: value}};
+
+				const history = spy(dare, 'execute', () => ([]));
+
+				await dare[method]({
+					table: 'mytable',
+					fields: ['id', 'name'],
+					body: {name: 'newvalue'},
+					filter: {status: 'boom'},
+					notfound: null
+				});
+
+				const [{sql, values}] = history.at(0);
+
+				expect(sql).to.include('status = ');
+				expect(values).to.not.include(method);
+				expect(values).to.include('boom');
+
+			});
+
+			it(`should be undefinedable within a dare.${method}() call`, async () => {
+
+				const value = method;
+
+				// Set the default value for the method
+				dare.options.models.mytable.schema.status = {defaultValue: {[method]: value}};
+
+				const history = spy(dare, 'execute', () => ([]));
+
+				await dare[method]({
+					table: 'mytable',
+					fields: ['id', 'name'],
+					body: {name: 'newvalue'},
+					filter: {status: undefined},
+					notfound: null
+				});
+
+				const [{sql, values}] = history.at(0);
+
+				/*
+				 * TODO: Should not include filters where the values are undefined
+				 * This should be akin to removing the defaultValue too
+				 */
+				expect(sql).to.include('status = ');
+				expect(values).to.not.include(method);
+				expect(values).to.include(undefined);
+
 			});
 
 		});


### PR DESCRIPTION
Implements #249

#### Field attribute: `defaultValue`
Defining the `defaultValue` introduces default conditions or values when querying or inserting records respectively.
`defaultValue` can be any value supported by the context it is used. If `defaultValue` is not an object, it will be applied to all operations, "methods" (`get`, `post`, `patch` and `del`). However when `defaultValue` is defined as an object, then the properties of the object matching the method will be used.
e.g we can define what `defaultValue` is used in various scenarios:
```js
defaultValue: {
	get: 'active', // Includes `= 'active'` to `.get` filter conditions.
	post: 'active', // Inserts `active` into new records
	del: 'inactive', // Includes `= 'inactive'` to `.del` filter conditions.
	// patch: is undefined and wont apply any default values
}
```
**`defaultValue`**
In the example we're going to set the defaultValue for the `users.status` field to `"active"`.
```js
const dare = new Dare({
	models: {
		users: {
			schema: {
				status: {
					defaultValue: 'active'
				}
			}
		}
	}
});
// And now requests will by default include that value
await dare.post('users', {name: 'Andrew'}); // INSERT INTO users (name, status) VALUES ("Andrew", "active")
await dare.get('users', ['id'], {limit: 100}); // SELECT id FROM users WHERE status = 'active' LIMIT 100
// ... adds same condition for Del and Patch methods
```