### PR TITLE
fix(group_concat): remove the ghostly GROUP_CONCAT result

### DIFF
--- a/src/get.js
+++ b/src/get.js
@@ -109,7 +109,12 @@ export default function buildQuery(opts, dareInstance) {
 
 		// Generate a Group Concat statement of the result
 		const address = opts.field_alias_path || opts._joins[0].field_alias_path;
-		const gc = group_concat(fields, address);
+		/*
+		 * Sql_alias._rowid IS NOT NULL
+		 * Get a non intermediate table for use as the sql_alias._rowid value.
+		 */
+		const gc_sql_alias = opts.field_alias_path ? sql_alias : opts._joins[0].sql_alias;
+		const gc = group_concat(fields, address, gc_sql_alias);
 		sql_fields = [raw(gc.expression)];
 		alias = gc.label;
 
@@ -403,7 +408,12 @@ function traverse(item, is_subquery, dareInstance) {
 
 		// Generate a Group Concat statement of the result
 		const address = item.field_alias_path || item._joins[0].field_alias_path;
-		const gc = group_concat(fields, address);
+		/*
+		 * Sql_alias._rowid IS NOT NULL
+		 * Get a non intermediate table for use as the sql_alias._rowid value.
+		 */
+		const gc_sql_alias = item.field_alias_path ? sql_alias : item._joins[0].sql_alias;
+		const gc = group_concat(fields, address, gc_sql_alias);
 
 		// Reset the fields array
 		fields.length = 0;

--- a/src/utils/group_concat.js
+++ b/src/utils/group_concat.js
@@ -3,7 +3,7 @@
  * Label the GROUP CONCAT(..) AS 'address[fields,...]'
  * Wrap all the fields in a GROUP_CONCAT statement
  */
-export default function group_concat(fields, address = '') {
+export default function group_concat(fields, address = '', sql_alias) {
 
 	// Is this an aggregate list?
 	const agg = fields.reduce((prev, curr) => (prev || curr.agg || curr.label.indexOf(address) !== 0), false);
@@ -36,7 +36,7 @@ export default function group_concat(fields, address = '') {
 	}
 
 	// Multiple
-	expression = `CONCAT('[', GROUP_CONCAT(${expression}), ']')`;
+	expression = `CONCAT('[', GROUP_CONCAT(IF(${sql_alias}.id IS NOT NULL, ${expression}, '')), ']')`;
 
 	label = fields.map(field => {
 

--- a/test/specs/get-subquery.spec.js
+++ b/test/specs/get-subquery.spec.js
@@ -134,7 +134,7 @@ describe('get - subquery', () => {
 
 				SELECT a.name AS 'name',
 				(
-					SELECT CONCAT('[', GROUP_CONCAT(CONCAT_WS('', '[', '"', REPLACE(REPLACE(c.id, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ',', '"', REPLACE(REPLACE(c.name, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ']')), ']')
+					SELECT CONCAT('[', GROUP_CONCAT(IF(c.id IS NOT NULL, CONCAT_WS('', '[', '"', REPLACE(REPLACE(c.id, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ',', '"', REPLACE(REPLACE(c.name, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ']'), '')), ']')
 					FROM assetCollections b
 					LEFT JOIN collections c ON (c.id = b.collection_id)
 					WHERE b.asset_id = a.id
@@ -176,7 +176,7 @@ describe('get - subquery', () => {
 
 				SELECT a.name AS 'name',
 				(
-					SELECT CONCAT('[', GROUP_CONCAT(CONCAT_WS('', '[', '"', REPLACE(REPLACE(b.id, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ',', '"', REPLACE(REPLACE(b.color, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ']')), ']')
+					SELECT CONCAT('[', GROUP_CONCAT(IF(b.id IS NOT NULL, CONCAT_WS('', '[', '"', REPLACE(REPLACE(b.id, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ',', '"', REPLACE(REPLACE(b.color, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ']'), '')), ']')
 					FROM assetCollections b
 					WHERE b.color = ? AND b.asset_id = a.id
 					LIMIT 1
@@ -255,7 +255,7 @@ describe('get - subquery', () => {
 
 			const expected = `
 				SELECT a.name AS 'name',
-					CONCAT('[', GROUP_CONCAT(CONCAT_WS('', '[', '"', REPLACE(REPLACE(c.id, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ',', '"', REPLACE(REPLACE(c.name, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ']')), ']') AS 'collections[id,name]'
+					CONCAT('[', GROUP_CONCAT(IF(c.id IS NOT NULL, CONCAT_WS('', '[', '"', REPLACE(REPLACE(c.id, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ',', '"', REPLACE(REPLACE(c.name, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ']'), '')), ']') AS 'collections[id,name]'
 				FROM assets a
 				LEFT JOIN assetCollections b ON(b.asset_id = a.id)
 				LEFT JOIN collections c ON (c.id = b.collection_id)
@@ -290,7 +290,7 @@ describe('get - subquery', () => {
 		dare.sql = ({sql}) => {
 
 			const expected = `
-				SELECT a.name AS 'name', CONCAT('[',GROUP_CONCAT(CONCAT_WS('', '[', '"', REPLACE(REPLACE(COUNT(d.id), '\\\\', '\\\\\\\\'), '"','\\\\"'),'"',']')),']') AS 'assetCollections[collections.descendents]'
+				SELECT a.name AS 'name', CONCAT('[',GROUP_CONCAT(IF(b.id IS NOT NULL, CONCAT_WS('', '[', '"', REPLACE(REPLACE(COUNT(d.id), '\\\\', '\\\\\\\\'), '"','\\\\"'),'"',']'), '')),']') AS 'assetCollections[collections.descendents]'
 				FROM assets a
 				LEFT JOIN assetCollections b ON(b.asset_id = a.id)
 				LEFT JOIN collections c ON(c.id = b.collection_id)

--- a/test/specs/utils_group_concat.spec.js
+++ b/test/specs/utils_group_concat.spec.js
@@ -21,9 +21,9 @@ describe('utils/group_concat', () => {
 		}, {
 			expression: 'table.b',
 			label: 'collection.b'
-		}], 'collection.');
+		}], 'collection.', 'a');
 
-		expect(gc.expression).to.eql(`CONCAT('[', GROUP_CONCAT(CONCAT_WS('', '[', '"', REPLACE(REPLACE(table.a, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ',', '"', REPLACE(REPLACE(table.b, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ']')), ']')`);
+		expect(gc.expression).to.eql(`CONCAT('[', GROUP_CONCAT(IF(a.id IS NOT NULL, CONCAT_WS('', '[', '"', REPLACE(REPLACE(table.a, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ',', '"', REPLACE(REPLACE(table.b, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ']'), '')), ']')`);
 		expect(gc.label).to.eql('collection[a,b]');
 
 	});
@@ -63,9 +63,9 @@ describe('utils/group_concat', () => {
 		const gc = group_concat([{
 			expression: 'table.a',
 			label: 'collection.a'
-		}], 'collection.');
+		}], 'collection.', 'a');
 
-		expect(gc.expression).to.eql(`CONCAT('[', GROUP_CONCAT(CONCAT_WS('', '[', '"', REPLACE(REPLACE(table.a, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ']')), ']')`);
+		expect(gc.expression).to.eql(`CONCAT('[', GROUP_CONCAT(IF(a.id IS NOT NULL, CONCAT_WS('', '[', '"', REPLACE(REPLACE(table.a, '\\\\', '\\\\\\\\'), '"', '\\\\"'), '"', ']'), '')), ']')`);
 		expect(gc.label).to.eql('collection[a]');
 
 	});


### PR DESCRIPTION
Addresses an issue whereby no matched rows in a group_concat statement end up showing as an empty list.

The issue is raised [here](https://stackoverflow.com/questions/13762212/why-does-the-group-concat-bring-one-row-with-null-values-when-there-are-no-rows)

Before a group concat cell would return something where all the values are `""` (empty strings). Now with this change that default row isn't present.

```diff
- [["", "", ""]]
+ []
```

