### PR TITLE
feat(stream): support row streaming data from db

### DIFF
--- a/src/format/field_reducer.js
+++ b/src/format/field_reducer.js
@@ -200,7 +200,8 @@ function fieldMapping({field, label, fieldsArray, originalArray, field_alias_pat
 				field,
 				field_alias_path,
 				handler: generated_field,
-				extraFields
+				extraFields,
+				targetAddress: getTargetPath(field_alias_path, field)
 			});
 
 			return;
@@ -268,7 +269,8 @@ function fieldMapping({field, label, fieldsArray, originalArray, field_alias_pat
 			label,
 			field,
 			field_alias_path,
-			handler: item => jsonParse(item[label]) || {}
+			handler: item => jsonParse(item[label]) || {},
+			targetAddress: getTargetPath(field_alias_path, field)
 		});
 
 		// Continue...
@@ -316,5 +318,26 @@ function isEmpty(value) {
 function arrayDiff(a, b) {
 
 	return a.filter(item => !b.includes(item));
+
+}
+
+/**
+ * Get target path
+ * Given a model path, such as `picture`, reduce it of the parent path in the request path like `picture.url`
+ * So the result would be empty path because the target is on the base.
+ * If model path is `picture` and the request path is `url`, then the target path is just `picture`
+ * @param {string} modelPath - Model Path
+ * @param {string} requestPath - Request Path (incl. field)
+ * @returns {string} Target path
+ */
+export function getTargetPath(modelPath, requestPath) {
+
+	// Remove the field from the request Path
+	const requestModelPath = requestPath.slice(0, requestPath.lastIndexOf('.') + 1);
+
+	// Remove the requestModelPath from the modelPath
+	return modelPath.replace(new RegExp(`${requestModelPath}$`), '')
+		.split('.')
+		.filter(Boolean);
 
 }

--- a/test/integration/helpers/db.js
+++ b/test/integration/helpers/db.js
@@ -1,5 +1,5 @@
 import mysql from 'mysql2/promise';
-
+import {PassThrough} from 'node:stream';
 
 // Initiates the mysql connection
 class DB {
@@ -19,6 +19,20 @@ class DB {
 		const [rows] = await this.conn.query(query);
 
 		return rows;
+
+	}
+
+	stream(query, streamOptions = {objectMode: true, highWaterMark: 5}) {
+
+		const resultStream = new PassThrough(streamOptions);
+
+		// Stream query results from the DB
+		this.conn.connection
+			.query(query)
+			.stream(streamOptions)
+			.pipe(resultStream);
+
+		return resultStream;
 
 	}
 

--- a/test/integration/helpers/db.js
+++ b/test/integration/helpers/db.js
@@ -29,7 +29,7 @@ class DB {
 		// Stream query results from the DB
 		this.conn.connection
 			.query(query)
-			.stream(streamOptions)
+			.stream()
 			.pipe(resultStream);
 
 		return resultStream;

--- a/test/integration/stream.spec.js
+++ b/test/integration/stream.spec.js
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import Dare from '../../src/index.js';
+import Debug from 'debug';
+import mysql from 'mysql2/promise';
+import options from '../data/options.js';
+
+const debug = Debug('sql');
+
+const {db} = global;
+
+function dareStream() {
+
+	// Initiate
+	const dare = new Dare(options);
+
+	// Set a test instance
+	dare.execute = async function(query) {
+
+		// Define the current Dare Instance
+		const dareInstance = this;
+
+		// Debug: Show the formatted version
+		debug(mysql.format(query.sql, query.values));
+
+		// Return a promise out of a stream...
+		return new Promise((accept, reject) => {
+
+			// Note we're making a request for the Stream Object
+			const resultStream = db.stream(query);
+
+			// Event handlers...
+			resultStream.on('data', row => {
+
+				dareInstance.addRow(row);
+
+			});
+			resultStream.on('end', accept);
+			resultStream.on('error', reject);
+
+		});
+
+	};
+
+	return dare;
+
+}
+
+describe('Stream', () => {
+
+	let dare;
+
+	beforeEach(() => {
+
+		dare = dareStream();
+
+	});
+
+	it('should expose the stream of data through rowHandler', async () => {
+
+		// Populate users
+		const postUsers = Array(100).fill(0)
+			.map((_, index) => ({username: `User${index}`}));
+
+		await dare.post('users', postUsers);
+
+		// Push data out
+		const data = [];
+
+		// Retrieve a list of users via a stream
+		const resp = await dare.get({
+			table: 'users',
+			fields: ['username', 'generatedUrl'],
+			limit: 100,
+			rowHandler(row) {
+
+				data.push(row);
+
+			}
+		});
+
+		assert.strictEqual(resp, undefined, 'Resolved value should be undefined');
+		assert.strictEqual(data.length, 100, 'Intercept handler should contain 100 items');
+		assert.deepStrictEqual(data[0], {
+			username: 'User0',
+			generatedUrl: '/user/1'
+		}, 'Should return formated data');
+
+
+	});
+
+});

--- a/test/specs/get.spec.js
+++ b/test/specs/get.spec.js
@@ -522,5 +522,63 @@ describe('get', () => {
 
 	});
 
+	describe('rowHandler', () => {
+
+		it('should be settable from the dare.get({rowHandler}) option', async () => {
+
+			dare.execute = async () => ([{name: 'Jupiter'}]);
+
+			const resp = await dare.get({
+				table: 'test',
+				fields: ['name'],
+				rowHandler(row) {
+
+					row.age = 4;
+					return row;
+
+				}
+			});
+
+			expect(resp).to.have.property('name', 'Jupiter');
+			expect(resp).to.have.property('age', 4);
+
+
+		});
+
+		it('execute should be able to call addRow instead of returning an array', async () => {
+
+			const data = [];
+
+			dare.execute = async function() {
+
+				this.addRow({name: 'Jupiter'});
+
+			};
+
+			const resp = await dare.get({
+				table: 'test',
+				fields: ['name'],
+				rowHandler(row) {
+
+					row.age = 4;
+
+					// Add to external array
+					data.push(row);
+
+					// Do not return anything = does not add to internal resultset
+
+				}
+			});
+
+			expect(resp).to.equal(undefined);
+
+			expect(data[0]).to.have.property('name', 'Jupiter');
+			expect(data[0]).to.have.property('age', 4);
+
+
+		});
+
+	});
+
 });
 

--- a/test/specs/init.spec.js
+++ b/test/specs/init.spec.js
@@ -55,6 +55,26 @@ describe('Dare', () => {
 
 	});
 
+
+	it('execute should be able to call addRow', async () => {
+
+		const dare = new Dare();
+
+		dare.execute = async function() {
+
+			this.addRow({name: 'Jupiter'});
+
+		};
+
+		const resp = await dare.get({
+			table: 'test',
+			fields: ['name']
+		});
+
+		expect(resp).to.have.property('name', 'Jupiter');
+
+	});
+
 	describe('dare.use to extend the instance', () => {
 
 		let dare;

--- a/test/specs/response_handler.spec.js
+++ b/test/specs/response_handler.spec.js
@@ -1,4 +1,5 @@
 import Dare from '../../src/index.js';
+import {getTargetPath} from '../../src/format/field_reducer.js';
 
 describe('response_handler', () => {
 
@@ -181,7 +182,12 @@ describe('response_handler', () => {
 				handler,
 				extraFields
 			}
-		];
+		].map(obj => {
+
+			obj.targetAddress = getTargetPath(obj.field_alias_path, obj.field);
+			return obj;
+
+		});
 
 		const data = dare.response_handler([{
 			'field': 'value',
@@ -264,7 +270,12 @@ describe('response_handler', () => {
 				handler,
 				extraFields
 			}
-		];
+		].map(obj => {
+
+			obj.targetAddress = getTargetPath(obj.field_alias_path, obj.field);
+			return obj;
+
+		});
 
 		const data = dare.response_handler([{
 			'a[id,name]': '[["1","a"]]',


### PR DESCRIPTION
Fixes #263

Provides a mechanism to 
- stream row data from DB source
- format a record item with the Dare response handler
- push to a custom handler defined by `rowHandler` (which maps to the legacy `response_row_handler`)

All without creating an internal Array of results, which can be memory expensive.

This should create a more efficient approach to handling lots of data through a Dare SELECT query.
