### PR TITLE
fix(json-array): filtering empty nested joins

### DIFF
--- a/src/response_handler.js
+++ b/src/response_handler.js
@@ -105,10 +105,13 @@ function formatHandler(item) {
 				if (Array.isArray(value)) {
 					value.forEach(values => {
 						/*
-						 * This is a workaround/tidy up for GROUP_CONCAT/CONCAT_WS
-						 * If we can't find a non-empty value...
+						 * This is a workaround/tidy up for GROUP_CONCAT with JSON_ARRAY/CONCAT_WS
+						 * JSON_ARRAY can include a NULL value even if there is no matching join
+						 * CONCAT_WS would in the same circumstance return an empty string
 						 */
-						if (!values.find(val => val !== '')) {
+						const emptyValues =
+							process.env.MYSQL_VERSION === '5.6' ? '' : null;
+						if (!values.some(val => val !== emptyValues)) {
 							// Continue
 							return;
 						}

--- a/test/integration/get.spec.js
+++ b/test/integration/get.spec.js
@@ -120,6 +120,32 @@ describe(`Dare init tests: options ${Object.keys(options)}`, () => {
 		}
 
 		{
+			// Same Structure, team join is nulled
+			const resp = await dare.get({
+				table: 'users',
+				fields: [
+					{
+						userTeams: {
+							teams: ['id', 'name', 'description'],
+						},
+					},
+				],
+				join: {
+					userTeams: {
+						teams: {
+							name: 'not-available',
+						},
+					},
+				},
+			});
+
+			// UserTeams should be an empty array
+			expect(resp).to.deep.nested.include({
+				userTeams: [],
+			});
+		}
+
+		{
 			// Remap Structure
 			const resp = await dare.get({
 				table: 'users',

--- a/test/specs/response_handler.spec.js
+++ b/test/specs/response_handler.spec.js
@@ -346,13 +346,13 @@ describe('response_handler', () => {
 		});
 	});
 
-	it('should exclude a series of empty strings, a side-effect of inline GROUP_CONCAT', () => {
+	it('should exclude a series of NULL fields, a side-effect of inline GROUP_CONCAT', () => {
 		// Return a response field which is invalid
 		const data = dare.response_handler([
 			{
 				field: 'value',
 				'collection[id,name,assoc.id,assoc.name]':
-					'[["","","",""], ["","","",""]]',
+					'[[null, null, null, null], [null, null, null, null]]',
 			},
 		]);
 
@@ -373,6 +373,31 @@ describe('response_handler', () => {
 
 		expect(data).to.be.an('array');
 		expect(data[0]).to.deep.equal(item);
+	});
+
+	describe('mysql 5.6', () => {
+		afterEach(() => {
+			process.env.MYSQL_VERSION = undefined;
+		});
+
+		it('should exclude a series of empty strings, a side-effect of inline GROUP_CONCAT', () => {
+			process.env.MYSQL_VERSION = '5.6';
+
+			// Return a response field which is invalid
+			const data = dare.response_handler([
+				{
+					field: 'value',
+					'collection[id,name,assoc.id,assoc.name]':
+						'[["","","",""], ["","","",""]]',
+				},
+			]);
+
+			expect(data).to.be.an('array');
+			expect(data[0]).to.deep.equal({
+				collection: [],
+				field: 'value',
+			});
+		});
 	});
 });
 


### PR DESCRIPTION
Fixes issue where `null` responses now being returned by JSON_ARRAY (as we no longer have to cast as a string) should be omitted if it's an empty object altogether.