### PR TITLE
feat(shortcuts): initial shortcuts support, fixes #285

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,20 +909,18 @@ await dare.patch('users', {id: 321}, {id: 1337});
 // throws {code: INVALID_REFERENCE}
 ```
 
-#### Field attribute: `modelAlias`
+## `model.shortcut_map`
 
-modelAlias, can be used to create a shortcut to nested tables
+`shortcut_map`, can be used to define shortcut's to nested tables
 
 ```js
 const dare = dare.use({
-	infer_intermediate_joins: false, // `modelAlias` can be used to replace infer_intermediate_joins
+	infer_intermediate_joins: false, // A 'shortcut' can be used to replace infer_intermediate_joins
 
 	models: {
 		users: {
-			schema: {
-				myTeams: {
-					modelAlias: 'userTeams.team',
-				},
+			shortcut_map: {
+				myTeams: 'userTeams.team',
 			},
 		},
 	},

--- a/README.md
+++ b/README.md
@@ -909,6 +909,52 @@ await dare.patch('users', {id: 321}, {id: 1337});
 // throws {code: INVALID_REFERENCE}
 ```
 
+#### Field attribute: `modelAlias`
+
+modelAlias, can be used to create a shortcut to nested tables
+
+```js
+const dare = dare.use({
+	infer_intermediate_joins: false, // `modelAlias` can be used to replace infer_intermediate_joins
+
+	models: {
+		users: {
+			schema: {
+				myTeams: {
+					modelAlias: 'userTeams.team',
+				},
+			},
+		},
+	},
+});
+```
+
+The definition above will help simplify references to the `teams` model.
+
+```js
+const resp = await dare.get({
+	table: 'users',
+	fields: [
+		{
+			// Direct link to userTeams, automatically uses pivot table userTeams
+			myTeams: ['id', 'name'],
+		},
+	],
+	join: {
+		myTeams: {
+			'%name': '%team%',
+		},
+	},
+});
+// SELECT CONCAT('[', GROUP_CONCAT(IF(c._rowid IS NOT NULL, JSON_ARRAY(c.id,c.name), NULL)), ']') AS 'myTeams[id,name]'
+// FROM users a
+// LEFT JOIN userTeams b ON (b.user_id = a.id)
+// LEFT JOIN teams c ON (c.id = b.team_id)
+// WHERE c.name LIKE '%team%'
+// GROUP BY a._rowid
+// LIMIT 1
+```
+
 ## `model.get`
 
 Here's an example of setting a model to be invoked whenever we access `users` model, we'll go into each of the properties afterwards.

--- a/src/format/join_handler.js
+++ b/src/format/join_handler.js
@@ -31,20 +31,18 @@ export default function (join_object, root_object, dareInstance) {
 	}
 
 	/**
-	 * ModelAlias?
-	 * now check whether this alias is defined as a modelAlias
-	 * modelAlias is defined in the schema of the root table
-	 * And desrcibes the path (model joins) needed for the given data set
+	 * Shortcut?
+	 * now check whether this alias is defined as a Shortcut
+	 * Shortcut's are defined in the model of the root table
+	 * And desrcibes the path (model joins) needed for the given nested model
 	 */
 
-	const {modelAlias} = getFieldAttributes(
-		models[rootModel]?.schema?.[joinModel]
-	);
+	const shortcut = models[rootModel]?.shortcut_map?.[joinModel];
 
 	// The model alias is now present so we know we're on the right track
-	if (modelAlias) {
+	if (shortcut) {
 		// Decode the modelAlias and construct the joins
-		const [linkTable, joinModel] = modelAlias.split('.');
+		const [linkTable, joinModel] = shortcut.split('.');
 
 		// Update the underlying table
 		join_object.table = joinModel;

--- a/src/format/join_handler.js
+++ b/src/format/join_handler.js
@@ -30,6 +30,38 @@ export default function (join_object, root_object, dareInstance) {
 		return Object.assign(join_object, join_conditions);
 	}
 
+	/**
+	 * ModelAlias?
+	 * now check whether this alias is defined as a modelAlias
+	 * modelAlias is defined in the schema of the root table
+	 * And desrcibes the path (model joins) needed for the given data set
+	 */
+
+	const {modelAlias} = getFieldAttributes(
+		models[rootModel]?.schema?.[joinModel]
+	);
+
+	// The model alias is now present so we know we're on the right track
+	if (modelAlias) {
+		// Decode the modelAlias and construct the joins
+		const [linkTable, joinModel] = modelAlias.split('.');
+
+		// Update the underlying table
+		join_object.table = joinModel;
+
+		// Construct intermediate join
+		const intermediateJoin = findIntermediateJoin({
+			rootModel,
+			linkTable,
+			joinModel,
+			models,
+			join_object,
+		});
+
+		// Return, errors are thrown in format_request if this is undefined
+		return intermediateJoin;
+	}
+
 	/*
 	 * Is the infer_intermediate_models option is set to false?
 	 * --> can't guess which table to use, return null
@@ -40,56 +72,89 @@ export default function (join_object, root_object, dareInstance) {
 
 	// Crawl the schema for an intermediate table which is linked to both tables. link table, ... we're only going for a single Kevin Bacon. More than that and the process will deem this operation too hard.
 	for (const linkTable in models) {
-		// Well, ignore models of the same name
-		if (linkTable === joinModel || linkTable === rootModel) {
-			continue;
+		// Construct intermediate join
+		const intermediateJoin = findIntermediateJoin({
+			rootModel,
+			linkTable,
+			joinModel,
+			models,
+			join_object,
+		});
+
+		if (intermediateJoin) {
+			return intermediateJoin;
 		}
-
-		// LinkTable <> joinTable?
-		const join_conditions =
-			links(models[joinModel]?.schema, linkTable) ||
-			invert_links(models[linkTable]?.schema, joinModel);
-
-		if (!join_conditions) {
-			continue;
-		}
-
-		// RootTable <> linkTable
-		const root_conditions =
-			links(models[linkTable]?.schema, rootModel) ||
-			invert_links(models[rootModel]?.schema, linkTable);
-
-		if (!root_conditions) {
-			continue;
-		}
-
-		/*
-		 * If both the root and join table are pointing to the same value in the linkTable
-		 * -> Abort
-		 * e.g.
-		 *	root_conditions: { join_conditions: { id: 'commentcountry_id' }, many: false },
-		 *	join_conditions: { join_conditions: { personcountry_id: 'id' }, many: true }
-		 */
-		if (
-			Object.keys(root_conditions.join_conditions).at(0) ===
-			Object.values(join_conditions.join_conditions).at(0)
-		) {
-			continue;
-		}
-
-		/*
-		 * Awesome, this table (tbl) is the link table and can be used to join up both these tables.
-		 * Also give this link table a unique Alias
-		 */
-		return {
-			table: linkTable,
-			joins: [Object.assign(join_object, join_conditions)],
-			...root_conditions,
-		};
 	}
 
 	// Return a falsy value
 	return null;
+}
+
+/**
+ * Find Intermediate joins
+ * Given root, link and target (join) names
+ * Find and constructs the join definitions (fields to connect)
+ * @param {object} object - Object
+ * @param {string} object.rootModel - Root model name
+ * @param {string} object.linkTable - Link model name
+ * @param {string} object.joinModel - Target/join model name
+ * @param {object} object.models - Model Options
+ * @param {object} object.join_object - Passthrough original join options
+ * @returns {object|undefined} Join definition to return
+ */
+function findIntermediateJoin({
+	rootModel,
+	linkTable,
+	joinModel,
+	models,
+	join_object,
+}) {
+	// Well, ignore models of the same name
+	if (linkTable === joinModel || linkTable === rootModel) {
+		return;
+	}
+
+	// LinkTable <> joinTable?
+	const join_conditions =
+		links(models[joinModel]?.schema, linkTable) ||
+		invert_links(models[linkTable]?.schema, joinModel);
+
+	if (!join_conditions) {
+		return;
+	}
+
+	// RootTable <> linkTable
+	const root_conditions =
+		links(models[linkTable]?.schema, rootModel) ||
+		invert_links(models[rootModel]?.schema, linkTable);
+
+	if (!root_conditions) {
+		return;
+	}
+
+	/*
+	 * If both the root and join table are pointing to the same value in the linkTable
+	 * -> Abort
+	 * e.g.
+	 *	root_conditions: { join_conditions: { id: 'commentcountry_id' }, many: false },
+	 *	join_conditions: { join_conditions: { personcountry_id: 'id' }, many: true }
+	 */
+	if (
+		Object.keys(root_conditions.join_conditions).at(0) ===
+		Object.values(join_conditions.join_conditions).at(0)
+	) {
+		return;
+	}
+
+	/*
+	 * Awesome, this table (tbl) is the link table and can be used to join up both these tables.
+	 * Also give this link table a unique Alias
+	 */
+	return {
+		table: linkTable,
+		joins: [Object.assign(join_object, join_conditions)],
+		...root_conditions,
+	};
 }
 
 function links(tableSchema, joinTable, flipped = false) {

--- a/test/integration/get.spec.js
+++ b/test/integration/get.spec.js
@@ -1,8 +1,7 @@
 import Dare, {DareError} from '../../src/index.js';
 import Debug from 'debug';
 import mysql from 'mysql2/promise';
-import {options} from './helpers/api.js';
-
+import {options, castToStringIfNeeded} from './helpers/api.js';
 const debug = Debug('sql');
 
 const {db} = global;
@@ -92,12 +91,6 @@ describe(`Dare init tests: options ${Object.keys(options)}`, () => {
 			team_id: team.insertId,
 		});
 
-		// eslint-disable-next-line func-style
-		let wrapper = a => a;
-		if (process.env.MYSQL_VERSION === '5.6') {
-			wrapper = a => (a === null ? '' : String(a));
-		}
-
 		{
 			// Same Structure
 			const resp = await dare.get({
@@ -113,9 +106,9 @@ describe(`Dare init tests: options ${Object.keys(options)}`, () => {
 
 			expect(resp).to.deep.nested.include({
 				'userTeams[0].teams': {
-					id: wrapper(team.insertId),
+					id: castToStringIfNeeded(team.insertId),
 					name: teamName,
-					description: wrapper(null),
+					description: castToStringIfNeeded(null),
 				},
 			});
 		}
@@ -160,9 +153,9 @@ describe(`Dare init tests: options ${Object.keys(options)}`, () => {
 			});
 
 			expect(resp).to.deep.nested.equal({
-				id: wrapper(team.insertId),
+				id: castToStringIfNeeded(team.insertId),
 				name: teamName,
-				description: wrapper(null),
+				description: castToStringIfNeeded(null),
 			});
 		}
 

--- a/test/integration/helpers/api.js
+++ b/test/integration/helpers/api.js
@@ -30,3 +30,12 @@ export default function () {
 
 	return dare;
 }
+
+export function castToStringIfNeeded(a) {
+	// MySQL 5.6, uses CONCAT_WS, rather than type safe JSON_ARRAY
+	if (process.env.MYSQL_VERSION === '5.6') {
+		return a === null ? '' : String(a);
+	}
+
+	return a;
+}

--- a/test/integration/modelAlias.spec.js
+++ b/test/integration/modelAlias.spec.js
@@ -1,4 +1,4 @@
-import Dare, {DareError} from '../../src/index.js';
+import Dare from '../../src/index.js';
 import Debug from 'debug';
 import mysql from 'mysql2/promise';
 import {options, castToStringIfNeeded} from './helpers/api.js';

--- a/test/integration/modelAlias.spec.js
+++ b/test/integration/modelAlias.spec.js
@@ -1,0 +1,87 @@
+import Dare, {DareError} from '../../src/index.js';
+import Debug from 'debug';
+import mysql from 'mysql2/promise';
+import {options, castToStringIfNeeded} from './helpers/api.js';
+
+const debug = Debug('sql');
+
+const {db} = global;
+
+// Connect to db
+
+describe(`schema: modelAlias`, () => {
+	let dare;
+
+	beforeEach(() => {
+		// Initiate
+		dare = new Dare(options);
+
+		// Extend
+		dare = dare.use({
+			// Disable infer intermediate model
+			infer_intermediate_models: false,
+
+			// Create a modelAlias
+			models: {
+				users: {
+					schema: {
+						myTeams: {
+							modelAlias: 'userTeams.teams',
+						},
+					},
+				},
+			},
+		});
+
+		// Set a test instance
+		// eslint-disable-next-line arrow-body-style
+		dare.execute = query => {
+			// DEBUG
+			debug(mysql.format(query.sql, query.values));
+
+			return db.query(query);
+		};
+	});
+
+	it('should be able to use a modelAlias to describe the model links', async () => {
+		const teamName = 'A Team';
+
+		// Create users, team and add the two
+		const [user, team] = await Promise.all([
+			// Create user
+			dare.post('users', {username: 'user123'}),
+
+			// Create team
+			dare.post('teams', {name: teamName}),
+		]);
+
+		// Add to the pivot table
+		await dare.post('userTeams', {
+			user_id: user.insertId,
+			team_id: team.insertId,
+		});
+
+		// Test
+		const resp = await dare.get({
+			table: 'users',
+			fields: [
+				{
+					// Direct link to userTeams, automatically uses pivot table userTeams
+					myTeams: ['id', 'name'],
+				},
+			],
+			join: {
+				myTeams: {
+					'%name': '%team%',
+				},
+			},
+		});
+
+		expect(resp).to.deep.nested.include({
+			'myTeams[0]': {
+				id: castToStringIfNeeded(team.insertId),
+				name: teamName,
+			},
+		});
+	});
+});

--- a/test/integration/shortcut_map.spec.js
+++ b/test/integration/shortcut_map.spec.js
@@ -9,7 +9,7 @@ const {db} = global;
 
 // Connect to db
 
-describe(`schema: modelAlias`, () => {
+describe(`model.shortcut_map`, () => {
 	let dare;
 
 	beforeEach(() => {
@@ -21,13 +21,12 @@ describe(`schema: modelAlias`, () => {
 			// Disable infer intermediate model
 			infer_intermediate_models: false,
 
-			// Create a modelAlias
+			// Create a shortcut_map
 			models: {
 				users: {
-					schema: {
-						myTeams: {
-							modelAlias: 'userTeams.teams',
-						},
+					// Create a shortcut definition on the `users' model
+					shortcut_map: {
+						myTeams: 'userTeams.teams',
 					},
 				},
 			},
@@ -43,7 +42,7 @@ describe(`schema: modelAlias`, () => {
 		};
 	});
 
-	it('should be able to use a modelAlias to describe the model links', async () => {
+	it('should be able to use a shortcut_map entries to dictate the model links', async () => {
 		const teamName = 'A Team';
 
 		// Create users, team and add the two

--- a/test/specs/join_handler.spec.js
+++ b/test/specs/join_handler.spec.js
@@ -222,6 +222,47 @@ describe('join_handler', () => {
 		expect(no_join).to.deep.equal(null);
 	});
 
+	it('should use the modelAlias to infer the connecting model', () => {
+		const dareInst = dare.use({
+			infer_intermediate_models: false,
+			models: {
+				grandparent: {},
+				parent: {
+					schema: {grand_id: ['grandparent.gid']},
+				},
+				child: {
+					schema: {
+						grandparents: {
+							modelAlias: 'parent.grandparent',
+						},
+						parent_id: ['parent.id'],
+					},
+				},
+			},
+		});
+
+		const child_object = {
+			alias: 'child',
+			table: 'child',
+		};
+
+		const grandparent_object = {
+			alias: 'grandparents',
+			table: 'grandparents',
+		};
+
+		const join = joinHandler(grandparent_object, child_object, dareInst);
+
+		expect(join).to.deep.equal({
+			table: 'parent',
+			join_conditions: {
+				id: 'parent_id',
+			},
+			many: false,
+			joins: [grandparent_object],
+		});
+	});
+
 	describe('many to many table joins', () => {
 		beforeEach(() => {
 			/*

--- a/test/specs/join_handler.spec.js
+++ b/test/specs/join_handler.spec.js
@@ -222,7 +222,7 @@ describe('join_handler', () => {
 		expect(no_join).to.deep.equal(null);
 	});
 
-	it('should use the modelAlias to infer the connecting model', () => {
+	it('should use the shortcuts to infer the connecting model', () => {
 		const dareInst = dare.use({
 			infer_intermediate_models: false,
 			models: {
@@ -231,10 +231,10 @@ describe('join_handler', () => {
 					schema: {grand_id: ['grandparent.gid']},
 				},
 				child: {
+					shortcut_map: {
+						grandparents: 'parent.grandparent',
+					},
 					schema: {
-						grandparents: {
-							modelAlias: 'parent.grandparent',
-						},
 						parent_id: ['parent.id'],
 					},
 				},


### PR DESCRIPTION
Fixes #285

Implement model shortcuts `models[model].shortcut_map : Map<>` provides a way to create deterministic shortcut routes to replace `infer_intermediate_joins` options.