### PR TITLE
feat(getFieldKey): interpret field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,45 @@ dare.post('emails', {hello: "What's this?"});
 // Someone should write field definitions for hello 👉`
 ```
 
+# `options.getFieldKey`
+
+The `options.getFieldKey` is used to obtain the correct schema field definition and SQL field name. This can be useful when allowing queries to be written in camelCase, but where the fields and the schema use snake_case.
+
+e.g.
+
+```js
+// Create a new dare instance
+dare = dare.use({
+	getFieldKey(field, schema) {
+		// Normal
+		if (field in schema) {
+			return field;
+		}
+		// Convert camelCase to snake_case
+		const snakeCase = field.replaceAll(
+			/[A-Z]+/g,
+			(m, index) => `${index > 0 ? '_' : ''}${m.toLowerCase()}`
+		);
+		if (snakeCase in schema) {
+			return snakeCase;
+		}
+
+		return field;
+	},
+});
+
+// CamelCase parameters here...
+await dare.patch('users', {lastName}, {firstName});
+
+// Get's mapped to snake_case parameters here
+//  UPDATE users a
+// 	SET
+// 		a.`first_name` = 'B'
+// 	WHERE
+// 		a.last_name = 'Name'
+// 	LIMIT 1
+```
+
 # `options.rowHandler`
 
 The `options.rowHandler` can be used to additionally preformat the response array, whilst it's already iterating on the response, or to redirect the records to another service (When this is used with [Streaming](#Streaming) it can drastically reduce the memory used by Dare).

--- a/src/format/field_reducer.js
+++ b/src/format/field_reducer.js
@@ -173,7 +173,8 @@ function fieldMapping({
 
 	// Get the schema entry for the field
 	const {handler, alias, type, readable} = getFieldAttributes(
-		table_schema[field_name]
+		field_name,
+		table_schema
 	);
 
 	// Is this readable?

--- a/src/format/field_reducer.js
+++ b/src/format/field_reducer.js
@@ -174,7 +174,8 @@ function fieldMapping({
 	// Get the schema entry for the field
 	const {handler, alias, type, readable} = getFieldAttributes(
 		field_name,
-		table_schema
+		table_schema,
+		dareInstance
 	);
 
 	// Is this readable?

--- a/src/format/join_handler.js
+++ b/src/format/join_handler.js
@@ -160,7 +160,7 @@ function links(tableSchema, joinTable, flipped = false) {
 
 	// Loop through the table fields
 	for (const field in tableSchema) {
-		const {references} = getFieldAttributes(tableSchema[field]);
+		const {references} = getFieldAttributes(field, tableSchema);
 
 		let ref = references || [];
 

--- a/src/format/orderby_reducer.js
+++ b/src/format/orderby_reducer.js
@@ -27,7 +27,7 @@ export default ({current_path, extract, table_schema}) =>
 
 		if (address_split.length <= 1) {
 			// Get the alias
-			const {alias} = getFieldAttributes(table_schema[item.field_name]);
+			const {alias} = getFieldAttributes(item.field_name, table_schema);
 
 			if (alias) {
 				// This is an alias column, override the field

--- a/src/format/orderby_reducer.js
+++ b/src/format/orderby_reducer.js
@@ -4,7 +4,7 @@ import mapReduce from '../utils/map_reduce.js';
 import orderbyUnwrap from '../utils/orderby_unwrap.js';
 import getFieldAttributes from '../utils/field_attributes.js';
 
-export default ({current_path, extract, table_schema}) =>
+export default ({current_path, extract, table_schema, dareInstance}) =>
 	mapReduce(entry => {
 		let field = entry;
 		let direction = '';
@@ -27,7 +27,11 @@ export default ({current_path, extract, table_schema}) =>
 
 		if (address_split.length <= 1) {
 			// Get the alias
-			const {alias} = getFieldAttributes(item.field_name, table_schema);
+			const {alias} = getFieldAttributes(
+				item.field_name,
+				table_schema,
+				dareInstance
+			);
 
 			if (alias) {
 				// This is an alias column, override the field

--- a/src/format/reducer_conditions.js
+++ b/src/format/reducer_conditions.js
@@ -14,11 +14,18 @@ import unwrap_field from '../utils/unwrap_field.js';
  * @param {string} options.sql_alias - Table SQL Alias, e.g. 'a', 'b', etc..
  * @param {object} options.table_schema - Table schema
  * @param {string|null} options.conditional_operators_in_value - Allowable conditional operators in value
+ * @param {object} options.dareInstance - Dare Instance
  * @returns {Array} Conditions object converted to SQL
  */
 export default function reduceConditions(
 	filter,
-	{extract, sql_alias, table_schema, conditional_operators_in_value}
+	{
+		extract,
+		sql_alias,
+		table_schema,
+		conditional_operators_in_value,
+		dareInstance,
+	}
 ) {
 	const filterArr = [];
 
@@ -54,6 +61,7 @@ export default function reduceConditions(
 					table_schema,
 					operators,
 					conditional_operators_in_value,
+					dareInstance,
 				})
 			);
 		}
@@ -91,8 +99,9 @@ function prepCondition({
 	table_schema,
 	operators,
 	conditional_operators_in_value,
+	dareInstance,
 }) {
-	const {type, alias} = getFieldAttributes(field, table_schema);
+	const {type, alias} = getFieldAttributes(field, table_schema, dareInstance);
 
 	// Does it have a negative comparison operator?
 	const negate = operators?.includes('-');

--- a/src/format/reducer_conditions.js
+++ b/src/format/reducer_conditions.js
@@ -46,14 +46,12 @@ export default function reduceConditions(
 			// Format key and validate path
 			key = checkKey(key);
 
-			const key_definition = table_schema[key];
-
 			filterArr.push(
 				prepCondition({
 					field: key,
 					value,
 					sql_alias,
-					key_definition,
+					table_schema,
 					operators,
 					conditional_operators_in_value,
 				})
@@ -90,11 +88,11 @@ function prepCondition({
 	field,
 	value,
 	sql_alias,
-	key_definition,
+	table_schema,
 	operators,
 	conditional_operators_in_value,
 }) {
-	const {type, alias} = getFieldAttributes(key_definition);
+	const {type, alias} = getFieldAttributes(field, table_schema);
 
 	// Does it have a negative comparison operator?
 	const negate = operators?.includes('-');
@@ -244,7 +242,7 @@ function prepCondition({
 					field,
 					sql_alias,
 					value: item,
-					key_definition,
+					table_schema,
 					operators,
 					conditional_operators_in_value,
 				})

--- a/src/format_request.js
+++ b/src/format_request.js
@@ -125,8 +125,8 @@ async function format_request(options, dareInstance) {
 	 * Apply defaultValues to join
 	 */
 	{
-		Object.entries(table_schema).forEach(([key, value]) => {
-			const {defaultValue = {}} = getFieldAttributes(value);
+		Object.keys(table_schema).forEach(key => {
+			const {defaultValue = {}} = getFieldAttributes(key, table_schema);
 
 			/*
 			 * Check the defaultValue for the method has been assigned

--- a/src/format_request.js
+++ b/src/format_request.js
@@ -130,15 +130,27 @@ async function format_request(options, dareInstance) {
 
 			/*
 			 * Check the defaultValue for the method has been assigned
-			 * -> That there is no definition for the value in the filter and jopin options
+			 * -> That there is no definition for the value in the filter and join options
+			 * -> That we're trying to get their original field names
 			 */
-			if (
-				method in defaultValue &&
-				!(key in (options.filter || {})) &&
-				!(key in (options.join || {}))
-			) {
-				// Extend the join object with the default value
-				extend(options, {join: {[key]: defaultValue[method]}});
+			if (method in defaultValue) {
+				// Does the fields exist?
+				const filterHasKey = Object.keys({
+					...options.filter,
+					...options.joins,
+				})
+					.map(
+						filterKey =>
+							dareInstance.getFieldKey(filterKey, table_schema) ||
+							filterKey
+					)
+					.includes(key);
+
+				// If there is no match
+				if (!filterHasKey) {
+					// Extend the join object with the default value
+					extend(options, {join: {[key]: defaultValue[method]}});
+				}
 			}
 		});
 	}
@@ -197,6 +209,7 @@ async function format_request(options, dareInstance) {
 			sql_alias,
 			table_schema,
 			conditional_operators_in_value,
+			dareInstance,
 		});
 
 		options._filter = arr.length ? arr : null;
@@ -255,6 +268,7 @@ async function format_request(options, dareInstance) {
 			sql_alias,
 			table_schema,
 			conditional_operators_in_value,
+			dareInstance,
 		});
 
 		/*
@@ -303,7 +317,12 @@ async function format_request(options, dareInstance) {
 		const extract = extractJoined.bind(null, 'orderby', true);
 
 		// Set reducer options
-		const reducer = orderbyReducer({current_path, extract, table_schema});
+		const reducer = orderbyReducer({
+			current_path,
+			extract,
+			table_schema,
+			dareInstance,
+		});
 
 		// Return array of immediate props
 		options.orderby = toArray(options.orderby).reduce(reducer, []);

--- a/src/index.js
+++ b/src/index.js
@@ -493,11 +493,14 @@ Dare.prototype.post = async function post(table, body, opts = {}) {
 			 * Let's catch the omitted properties
 			 * --> Loop through the modelSchema
 			 */
-			Object.entries(modelSchema).forEach(([field, fieldObject]) => {
+			Object.keys(modelSchema).forEach(field => {
 				// For each property which was not covered by the input
 				if (field !== 'default' && !(field in item)) {
 					// Get a formatted object of field attributes
-					const fieldAttributes = getFieldAttributes(fieldObject);
+					const fieldAttributes = getFieldAttributes(
+						field,
+						modelSchema
+					);
 
 					/*
 					 * Get the default Value of the post operation
@@ -685,9 +688,9 @@ function onDuplicateKeysUpdate(keys = []) {
 function formatInputValue(tableSchema = {}, field, value, validateInput) {
 	const fieldAttributes =
 		field in tableSchema
-			? getFieldAttributes(tableSchema[field])
+			? getFieldAttributes(field, tableSchema)
 			: 'default' in tableSchema
-			? getFieldAttributes(tableSchema.default)
+			? getFieldAttributes('default', tableSchema)
 			: null;
 
 	const {alias, writeable, type} = fieldAttributes || {};
@@ -753,7 +756,7 @@ function formatInputValue(tableSchema = {}, field, value, validateInput) {
  * @returns {string} Unaliased field name
  */
 function unAliasFields(tableSchema = {}, field) {
-	const {alias} = getFieldAttributes(tableSchema[field]);
+	const {alias} = getFieldAttributes(field, tableSchema);
 	return alias || field;
 }
 

--- a/src/utils/field_attributes.js
+++ b/src/utils/field_attributes.js
@@ -6,8 +6,14 @@
  * @returns {object} An object containing the attributes of the field
  */
 
-export default (field, schema) => {
-	const fieldDefinition = schema[field];
+export default (field, schema, dareInstance) => {
+	const fieldKey = dareInstance?.getFieldKey?.(field, schema) || field;
+
+	const respDefinition = {
+		...(fieldKey !== field && {alias: fieldKey}),
+	};
+
+	const fieldDefinition = schema[fieldKey];
 
 	if (
 		fieldDefinition &&
@@ -34,12 +40,16 @@ export default (field, schema) => {
 		}
 
 		// This is already a definition object
-		return fieldDefinition;
+		return {
+			...respDefinition,
+			...fieldDefinition,
+		};
 	}
 
 	if (typeof fieldDefinition === 'string') {
 		// This is an alias reference, the name is an alias of another
 		return {
+			...respDefinition,
 			alias: fieldDefinition,
 		};
 	}
@@ -47,6 +57,7 @@ export default (field, schema) => {
 	if (Array.isArray(fieldDefinition)) {
 		// This is an reference to another table, this field can be used in a table join
 		return {
+			...respDefinition,
 			references: fieldDefinition,
 		};
 	}
@@ -54,6 +65,7 @@ export default (field, schema) => {
 	if (typeof fieldDefinition === 'function') {
 		// This is a generated field
 		return {
+			...respDefinition,
 			handler: fieldDefinition,
 		};
 	}
@@ -61,10 +73,13 @@ export default (field, schema) => {
 	if (fieldDefinition === false) {
 		// Mark as inaccessible
 		return {
+			...respDefinition,
 			readable: false,
 			writeable: false,
 		};
 	}
 
-	return {};
+	return {
+		...respDefinition,
+	};
 };

--- a/src/utils/field_attributes.js
+++ b/src/utils/field_attributes.js
@@ -1,11 +1,14 @@
 /**
  * Given a field definition defined in the schema, extract it's attributes
  *
- * @param {object|Function|string|undefined} fieldDefinition - A field definition as described in the schema
+ * @param {string} field - A field reference
+ * @param {object} schema - A model schema definition
  * @returns {object} An object containing the attributes of the field
  */
 
-export default fieldDefinition => {
+export default (field, schema) => {
+	const fieldDefinition = schema[field];
+
 	if (
 		fieldDefinition &&
 		typeof fieldDefinition === 'object' &&

--- a/test/data/options.js
+++ b/test/data/options.js
@@ -2,11 +2,22 @@ const created_time = {
 	type: 'datetime',
 };
 
+const string = {
+	type: 'string',
+};
+
 export default {
 	models: {
 		// Users table
 		users: {
 			schema: {
+				first_name: {
+					...string,
+				},
+				last_name: {
+					...string,
+				},
+
 				/*
 				 * Field alias
 				 * The DB schema defines `email` however our business requires that we can alias it as emailAddress

--- a/test/integration/getFieldKey.spec.js
+++ b/test/integration/getFieldKey.spec.js
@@ -1,0 +1,86 @@
+import Dare from '../../src/index.js';
+import Debug from 'debug';
+import mysql from 'mysql2/promise';
+import {options} from './helpers/api.js';
+const debug = Debug('sql');
+
+const {db} = global;
+
+// Connect to db
+
+describe(`getFieldKey`, () => {
+	let dare;
+
+	beforeEach(() => {
+		// Initiate
+		dare = new Dare(options);
+
+		// Set a test instance
+		// eslint-disable-next-line arrow-body-style
+		dare.execute = query => {
+			// DEBUG
+			debug(mysql.format(query.sql, query.values));
+
+			return db.query(query);
+		};
+	});
+
+	it('should be able to define a getFieldKey to deconstruct camelCase', async () => {
+		function getFieldKey(field, schema) {
+			// Normal
+			if (field in schema) {
+				return field;
+			}
+			// Convert camelCase to snake_case
+			const snakeCase = field.replaceAll(
+				/[A-Z]+/g,
+				(m, index) => `${index > 0 ? '_' : ''}${m.toLowerCase()}`
+			);
+			if (snakeCase in schema) {
+				return snakeCase;
+			}
+
+			return field;
+		}
+
+		// Overwrite get field definitiion
+		dare = dare.use({
+			getFieldKey,
+		});
+
+		const username = 'A Name';
+		let firstName = 'A';
+		const lastName = 'Name';
+
+		// Post using camelCase
+		await dare.post('users', {username, firstName, lastName});
+
+		{
+			// Test: changes were made
+			const resp = await dare.get(
+				'users',
+				['firstName'],
+				{lastName},
+				{orderby: 'firstName'}
+			);
+
+			expect(resp).to.have.property('firstName', firstName);
+		}
+
+		// Post using camelCase
+		firstName = 'B';
+		await dare.patch('users', {lastName}, {firstName});
+
+		{
+			// Test: changes were made
+			const resp = await dare.get(
+				'users',
+				['firstName'],
+				{lastName},
+				{orderby: 'firstName'}
+			);
+
+			expect(resp).to.have.property('firstName', firstName);
+		}
+	});
+});

--- a/test/specs/schema.defaultValue.spec.js
+++ b/test/specs/schema.defaultValue.spec.js
@@ -1,6 +1,6 @@
 import Dare from '../../src/index.js';
 
-import fieldAttributes from '../../src/utils/field_attributes.js';
+import getFieldAttributes from '../../src/utils/field_attributes.js';
 
 function spy(obj, func, callback) {
 	const history = [];
@@ -31,9 +31,11 @@ describe('schema.defaultValue', () => {
 		});
 	});
 
-	describe('fieldAttributes', () => {
+	describe('getFieldAttributes', () => {
+		const field = 'field';
+
 		it('defaultValue should not occur by default', () => {
-			const attr = fieldAttributes({});
+			const attr = getFieldAttributes(field, {});
 			expect(attr).to.not.have.property('defaultValue');
 		});
 
@@ -44,13 +46,15 @@ describe('schema.defaultValue', () => {
 				patch: null,
 			};
 
-			const attr = fieldAttributes({defaultValue});
+			const attr = getFieldAttributes(field, {[field]: {defaultValue}});
 			expect(attr).to.have.property('defaultValue', defaultValue);
 		});
 
 		[undefined, 1, null, 'string'].forEach(defaultValue => {
 			it(`should expand defaultValue, ${defaultValue}`, () => {
-				const attr = fieldAttributes({defaultValue});
+				const attr = getFieldAttributes(field, {
+					[field]: {defaultValue},
+				});
 				expect(attr).to.have.property('defaultValue').to.deep.equal({
 					post: defaultValue,
 					get: defaultValue,


### PR DESCRIPTION
Fixes #284

Defines a customisable function `options.getFieldKey` to map field names to names in the model schema.