### PR TITLE
fix(fields): allow forward slash within quotes, fixes 5app/hub#14234

### DIFF
--- a/src/utils/unwrap_field.js
+++ b/src/utils/unwrap_field.js
@@ -29,7 +29,7 @@ export default function unwrap_field(expression, allowValue = true) {
 			// Split out comma variables
 			while (
 				(int_m = str.match(
-					/(.*)(,\s*((?<quote>["'])?[\s\w%.-]*\k<quote>))$/i
+					/(.*)(,\s*((?<quote>["'])?[\s\w%./-]*\k<quote>))$/i
 				))
 			) {
 				/*

--- a/test/specs/unwrap_field.spec.js
+++ b/test/specs/unwrap_field.spec.js
@@ -46,6 +46,7 @@ describe('utils/unwrap_field', () => {
 		"FORMAT(ROUND(field * 5, 2), 'en_GB')",
 		"FORMAT(ROUND(field * 5.5, 2), 'en_GB')",
 		"FORMAT(ROUND(field / 5, 2), 'en_GB')",
+		'DATE(CONVERT_TZ(field, "UTC", "Europe/London"))',
 	].forEach(test => {
 		it(`where ${JSON.stringify(test)}`, () => {
 			// Call the field with the


### PR DESCRIPTION
Adds support for a forward slash `/` within quotes on a field