### PR TITLE
feat(fulltext): fulltext and cross-field search

### DIFF
--- a/src/format/join_handler.js
+++ b/src/format/join_handler.js
@@ -188,7 +188,7 @@ function links(tableSchema, joinTable, dareInstance, flipped = false) {
 		? {
 				join_conditions: flipped ? invert(map) : map,
 				many: !flipped,
-		  }
+			}
 		: null;
 }
 

--- a/src/format/reducer_conditions.js
+++ b/src/format/reducer_conditions.js
@@ -5,6 +5,13 @@ import formatDateTime from '../utils/format_datetime.js';
 import getFieldAttributes from '../utils/field_attributes.js';
 import unwrap_field from '../utils/unwrap_field.js';
 
+/* eslint-disable jsdoc/valid-types */
+/**
+ * @typedef {import('sql-template-tag').Sql} Sql
+ * @typedef {import('../index.js').default} Dare
+ */
+/* eslint-enable jsdoc/valid-types */
+
 /**
  * Reduce conditions, call extract
  *
@@ -14,8 +21,8 @@ import unwrap_field from '../utils/unwrap_field.js';
  * @param {string} options.sql_alias - Table SQL Alias, e.g. 'a', 'b', etc..
  * @param {object} options.table_schema - Table schema
  * @param {string|null} options.conditional_operators_in_value - Allowable conditional operators in value
- * @param {object} options.dareInstance - Dare Instance
- * @returns {Array} Conditions object converted to SQL
+ * @param {Dare} options.dareInstance - Dare Instance
+ * @returns {Array<Sql>} Conditions object converted to an array of SQL conditions
  */
 export default function reduceConditions(
 	filter,
@@ -55,9 +62,6 @@ export default function reduceConditions(
 			// Add it to the join table
 			extract(rootKeyRaw, value);
 		} else {
-			// Format key and validate path
-			key = checkKey(key);
-
 			filterArr.push(
 				prepCondition({
 					field: key,
@@ -88,7 +92,7 @@ function stripKey(key) {
 	let rootKey = rootKeyRaw;
 
 	// Does this have a comparison operator prefix?
-	const operators = rootKeyRaw.match(/^[%~-]+/)?.[0];
+	const operators = rootKeyRaw.match(/^[%*~-]+/)?.[0];
 	if (operators) {
 		// Strip the special operators from the prop
 		rootKey = rootKeyRaw.substring(operators.length);
@@ -97,6 +101,18 @@ function stripKey(key) {
 	return {rootKey, rootKeyRaw, subKey, operators};
 }
 
+/**
+ * Prep condition
+ * @param {object} params - Params
+ * @param {string} params.field - Field name
+ * @param {string} params.value - Field value
+ * @param {string} params.sql_alias - SQL Alias
+ * @param {object} params.table_schema - Table schema
+ * @param {string|null} params.operators - Allowable operators
+ * @param {string|null} params.conditional_operators_in_value - Allowable conditional operators in value
+ * @param {Dare} params.dareInstance - Dare Instance
+ * @returns {Sql} SQL condition
+ */
 function prepCondition({
 	field,
 	value,
@@ -106,8 +122,6 @@ function prepCondition({
 	conditional_operators_in_value,
 	dareInstance,
 }) {
-	const {type, alias} = getFieldAttributes(field, table_schema, dareInstance);
-
 	// Does it have a negative comparison operator?
 	const negate = operators?.includes('-');
 
@@ -116,6 +130,9 @@ function prepCondition({
 
 	// Does it have a Range comparison operator
 	const isRange = operators?.includes('~');
+
+	// Does it have a FullText comparison operator
+	const isFullText = operators?.includes('*');
 
 	// Allow conditional likey operator in value
 	const allow_conditional_likey_operator_in_value =
@@ -129,32 +146,60 @@ function prepCondition({
 	const allow_conditional_range_operator_in_value =
 		conditional_operators_in_value?.includes('~');
 
-	if (alias) {
-		// The key definition says the key is an alias
-		field = alias;
-	}
-
-	// Define the field definition
-	let sql_field = raw(`${sql_alias}.${field}`);
+	// Set a handly NOT value
+	const NOT = negate ? raw('NOT ') : empty;
 
 	/*
-	 * Should the field contain a SQL Function itself
-	 * -> Let's extract it...
+	 * Is the field an array of field names?
+	 * Then we're going to perform an A=value OR B=value OR C=value... type query
 	 */
-	if (/[^\w$.]/.test(field)) {
-		const {prefix, suffix, field: rawField} = unwrap_field(field);
+	if (!isFullText && field.includes(',')) {
+		// Split the fields
+		const fields = field.split(',');
 
-		// Ammend the sql_field
-		sql_field = raw(`${prefix}${sql_alias}.${rawField}${suffix}`);
+		return SQL`${NOT}(${join(
+			fields.map(field =>
+				prepCondition({
+					field,
+					value,
+					sql_alias,
+					table_schema,
+					operators: operators?.replace('-', ''),
+					conditional_operators_in_value,
+					dareInstance,
+				})
+			),
+			' OR '
+		)})`;
 	}
+
+	const sql_fields = getSqlFields({
+		field,
+		sql_alias,
+		table_schema,
+		dareInstance,
+	});
+
+	// Join the fields
+	const sql_field = join(
+		sql_fields.map(({sql}) => sql),
+		', '
+	);
+
+	if (isFullText) {
+		// Full Text
+		return SQL`${NOT}MATCH(${sql_field}) AGAINST(${value} IN BOOLEAN MODE)`;
+	}
+
+	const {type} = sql_fields.at(0);
+
+	// Update field
+	field = sql_fields.at(0).field;
 
 	// Format date time values
 	if (type === 'datetime') {
 		value = formatDateTime(value);
 	}
-
-	// Set a handly NOT value
-	const NOT = negate ? raw('NOT ') : empty;
 
 	/*
 	 * Range
@@ -224,8 +269,11 @@ function prepCondition({
 		const sub_values = [];
 		const conds = [];
 
-		// Filter the results of the array...
-		value = value.filter(item => {
+		/*
+		 * Filter the results of the array...
+		 * Remove things which can't be used within `IN`, i.e. where `NULL` comparison via `LIKE` etc...
+		 */
+		const filteredValue = value.filter(item => {
 			// Remove the items which can't in group statement...
 			if (
 				item !== null &&
@@ -245,8 +293,8 @@ function prepCondition({
 		});
 
 		// Use the `IN(...)` for items which can be grouped...
-		if (value.length) {
-			conds.push(SQL`${sql_field} ${NOT}IN (${value})`);
+		if (filteredValue.length) {
+			conds.push(SQL`${sql_field} ${NOT}IN (${filteredValue})`);
 		}
 
 		// Other Values which can't be grouped ...
@@ -271,4 +319,67 @@ function prepCondition({
 	} else {
 		return SQL`${sql_field} ${raw(negate ? '!' : '')}= ${value}`;
 	}
+}
+
+/**
+ * Get SQL fields
+ * @param {object} params - Params
+ * @param {string} params.field - Fields
+ * @param {string} params.sql_alias - SQL Alias
+ * @param {object} params.table_schema - Table schema
+ * @param {Dare} params.dareInstance - Dare Instance
+ * @returns {Array<{field: string, type: string, sql: Sql}>} SQL fields
+ */
+function getSqlFields({field, sql_alias, table_schema, dareInstance}) {
+	// Split the fields
+	const fields = field.split(',');
+
+	// Extract the field attributes, and in particular the alias, does it need further transformation?
+	return fields.flatMap(field => {
+		// Format key and validate path
+		field = checkKey(field);
+
+		const {alias, type} = getFieldAttributes(
+			field,
+			table_schema,
+			dareInstance
+		);
+
+		if (alias) {
+			// The key definition says the key is an alias
+			field = alias;
+
+			// Field contains a comma and no brackets, so it has an array of values, but is not a function
+			if (field.includes(',') && !field.includes('(')) {
+				// The alias has multiple fields
+				return getSqlFields({
+					field,
+					sql_alias,
+					table_schema,
+					dareInstance,
+				});
+			}
+		}
+
+		// Define the field definition
+		let sql = raw(`${sql_alias}.${field}`);
+
+		/*
+		 * Should the field contain a SQL Function itself
+		 * -> Let's extract it...
+		 */
+		if (/[^\w$.]/.test(field)) {
+			const {prefix, suffix, field: rawField} = unwrap_field(field);
+
+			// Ammend the sql_field
+			sql = raw(`${prefix}${sql_alias}.${rawField}${suffix}`);
+		}
+
+		// Derive the SQL field name
+		return {
+			field,
+			type,
+			sql,
+		};
+	});
 }

--- a/src/format_request.js
+++ b/src/format_request.js
@@ -10,6 +10,12 @@ import getFieldAttributes from './utils/field_attributes.js';
 import extend from './utils/extend.js';
 import buildQuery from './get.js';
 
+/* eslint-disable jsdoc/valid-types */
+/**
+ * @typedef {import('./index.js').default} Dare
+ */
+/* eslint-enable jsdoc/valid-types */
+
 /**
  * Format Request initiation
  *
@@ -19,12 +25,6 @@ import buildQuery from './get.js';
 export default function (options) {
 	return format_request(options, this);
 }
-
-/**
- * @typedef {object} Dare
- * @param {object} options - instance options
- * @param {Function} table_alias_handler - The db table this references
- */
 
 /**
  * Format Request
@@ -110,7 +110,7 @@ async function format_request(options, dareInstance) {
 			derivedMethod in model
 				? model[derivedMethod]
 				: // Or use the default model
-				  models?.default?.[derivedMethod];
+					models?.default?.[derivedMethod];
 
 		if (handler) {
 			// Trigger the handler which alters the options...

--- a/src/get.js
+++ b/src/get.js
@@ -151,7 +151,7 @@ export default function buildQuery(opts, dareInstance) {
 			opts.limit
 				? SQL`LIMIT ${opts.start ? raw(`${opts.start},`) : empty}${raw(
 						opts.limit
-				  )}`
+					)}`
 				: empty
 		}
 	`;

--- a/src/index.js
+++ b/src/index.js
@@ -283,9 +283,9 @@ Dare.prototype.get = async function get(table, fields, filter, options = {}) {
 	const opts =
 		typeof table === 'object'
 			? // Clone
-			  {...table}
+				{...table}
 			: // Clone and extend
-			  {...options, table, filter, fields};
+				{...options, table, filter, fields};
 
 	// Ensure fields is provided
 	if (typeof fields === 'object' && !Array.isArray(fields)) {
@@ -345,9 +345,9 @@ Dare.prototype.getCount = async function getCount(table, filter, options = {}) {
 	const opts =
 		typeof table === 'object'
 			? // Clone
-			  {...table}
+				{...table}
 			: // Clone and extend
-			  {...options, table, filter};
+				{...options, table, filter};
 
 	// Define method
 	opts.method = 'get';
@@ -395,9 +395,9 @@ Dare.prototype.patch = async function patch(table, filter, body, options = {}) {
 	const opts =
 		typeof table === 'object'
 			? // Clone
-			  {...table}
+				{...table}
 			: // Clone and extend
-			  {...options, table, filter, body};
+				{...options, table, filter, body};
 
 	// Define method
 	opts.method = 'patch';
@@ -475,9 +475,9 @@ Dare.prototype.post = async function post(table, body, options = {}) {
 	const opts =
 		typeof table === 'object'
 			? // Clone
-			  {...table}
+				{...table}
 			: // Clone and extend
-			  {...options, table, body};
+				{...options, table, body};
 
 	// Post
 	opts.method = 'post';
@@ -708,9 +708,9 @@ Dare.prototype.del = async function del(table, filter, options = {}) {
 	const opts =
 		typeof table === 'object'
 			? // Clone
-			  {...table}
+				{...table}
 			: // Clone and extend
-			  {...options, table, filter};
+				{...options, table, filter};
 
 	// Delete
 	opts.method = 'del';

--- a/test/integration/data/schema.sql
+++ b/test/integration/data/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE `users` (
   `country_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unique_username` (`username`),
+  FULLTEXT KEY `fulltext_users_fields` (`username`, `first_name`, `last_name`),
   -- country
 	KEY `fk_users_country_id` (`country_id`),
   CONSTRAINT `fk_users_country_id` FOREIGN KEY (`country_id`) REFERENCES `country` (`id`)

--- a/test/integration/get.spec.js
+++ b/test/integration/get.spec.js
@@ -179,4 +179,32 @@ describe(`Dare init tests: options ${Object.keys(options)}`, () => {
 			expect(resp).to.deep.nested.equal({});
 		}
 	});
+
+	it('Can search via fulltext', async () => {
+		const username = 'A Name';
+		await dare.post('users', {
+			username,
+			first_name: 'First',
+			last_name: 'Last',
+		});
+
+		// Search across multiple fields
+		{
+			const resp = await dare.get('users', ['username'], {
+				'*username,first_name,last_name': 'Name Fir* Las*',
+			});
+			expect(resp).to.have.property('username', username);
+		}
+
+		// And use an alias of the fulltext field
+		{
+			dare.options.models.users.schema.textsearch =
+				'username,first_name,last_name';
+
+			const resp = await dare.get('users', ['username'], {
+				'*textsearch': 'Name Fir* Las*',
+			});
+			expect(resp).to.have.property('username', username);
+		}
+	});
 });

--- a/test/specs/filter_reducer.spec.js
+++ b/test/specs/filter_reducer.spec.js
@@ -1,0 +1,101 @@
+import {expect} from 'chai';
+/*
+ * Filter Reducer
+ * Extract the filter conditions from the given conditions
+ */
+
+import reduceConditions from '../../src/format/reducer_conditions.js';
+
+describe('Filter Reducer', () => {
+	let dareInstance;
+	const conditional_operators_in_value = null;
+	let table_schema = null;
+	// eslint-disable-next-line func-style
+	const extract = () => {
+		// Do nothing
+	};
+
+	// Mock instance of Dare
+	beforeEach(() => {
+		dareInstance = {};
+		table_schema = {
+			textsearch: 'givenname,lastname,email',
+		};
+	});
+
+	describe('should prep conditions', () => {
+		const a = [
+			[{prop: 'string'}, 'a.prop = ?', ['string']],
+			[
+				{
+					'givenname,lastname,email': 'test string',
+				},
+				`(a.givenname = ? OR a.lastname = ? OR a.email = ?)`,
+				['test string', 'test string', 'test string'],
+			],
+			[
+				{
+					'%givenname,lastname,email': 'test string',
+				},
+				`(a.givenname LIKE ? OR a.lastname LIKE ? OR a.email LIKE ?)`,
+				['test string', 'test string', 'test string'],
+			],
+			[
+				{
+					'-givenname,lastname,email': 'test string',
+				},
+				`NOT (a.givenname = ? OR a.lastname = ? OR a.email = ?)`,
+				['test string', 'test string', 'test string'],
+			],
+			[
+				{
+					'*givenname,lastname,email': 'test string',
+				},
+				`MATCH(a.givenname, a.lastname, a.email) AGAINST(? IN BOOLEAN MODE)`,
+				['test string'],
+			],
+			[
+				{
+					'-*givenname,lastname,email': 'test string',
+				},
+				`NOT MATCH(a.givenname, a.lastname, a.email) AGAINST(? IN BOOLEAN MODE)`,
+				['test string'],
+			],
+			[
+				{
+					'*textsearch': 'test string',
+				},
+				`MATCH(a.givenname, a.lastname, a.email) AGAINST(? IN BOOLEAN MODE)`,
+				['test string'],
+			],
+		];
+
+		a.forEach(async test => {
+			const [filter, sql, values, options] = test;
+
+			// Clone filter
+			const filter_cloned = structuredClone(filter);
+
+			it(`should transform condition ${JSON.stringify(
+				filter
+			)} -> ${JSON.stringify(sql)}`, async () => {
+				if (options) {
+					dareInstance = dareInstance.use(options);
+				}
+				const [query] = reduceConditions(filter, {
+					extract,
+					sql_alias: 'a',
+					table_schema,
+					conditional_operators_in_value,
+					dareInstance,
+				});
+
+				expect(query.sql).to.equal(sql);
+				expect(query.values).to.deep.equal(values);
+
+				// Should not mutate the filters...
+				expect(filter).to.deep.eql(filter_cloned);
+			});
+		});
+	});
+});


### PR DESCRIPTION
Fixes #324

Adds MySQL FullText syntax and cross field search capabilities

| Key        | Value                    | Type          | = SQL Condition                                                                                                                             |
| ---------- | ------------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
| \*text     | '+And\*'                 | Pattern       | `MATCH(text) AGAINST('+And*' IN BOOLEAN MODE)`                                                                                              |
| name,email | 'hello'                  | any           | `(name = 'hello' OR email = 'hello')`                                                                                                       


## Fulltext Search

Dare support MySQL's FullText search syntax. The `*` symbol preceeding the key in a condition denote _compare using a fulltext search syntax_.

A prerequirement for FullText Search is that the corresponding FullText Index has been created for the fields being accessed.

i.e.

```js
await dare.get({
	table: 'users',
	fields: ['name'],
	filter: {
		'*name': 'Andrew',
	},
});
// SELECT name FROM users WHERE MATCH(name) AGAINST ('Andrew' IN BOOLEAN MODE)
```

The approach also supports multiple field definitions in the key, i.e.

```js
  filter: {
	'*name,email': 'Andrew',
  }
// SELECT name FROM users WHERE MATCH(name, email) AGAINST ('Andrew' IN BOOLEAN MODE)
```

> [!NOTE]
> It might be handy to create a new field in the Model Schema which aliases all the Indexed fields, i.e...
>
> ```js
> schema: {
> 	textsearch: 'name,email';
> }
> ```
>
> Now the filter would just call the alias name, and there's only one place to change it.
>
> ```js
>  filter: {
> 	'*textsearch': 'Andrew',
>  }
> // SELECT name FROM users WHERE MATCH(name, email) AGAINST ('Andrew' IN BOOLEAN MODE)
> ```