### PR TITLE
fix(fulltext): parse input, quote incompatible strings, #324

### DIFF
--- a/src/format/reducer_conditions.js
+++ b/src/format/reducer_conditions.js
@@ -164,7 +164,7 @@ function prepCondition({
 		);
 
 		// Full Text
-		return SQL`${NOT}MATCH(${sql_field}) AGAINST(${value} IN BOOLEAN MODE)`;
+		return SQL`${NOT}MATCH(${sql_field}) AGAINST(${dareInstance.fulltextParser(value)} IN BOOLEAN MODE)`;
 	} else if (sql_fields.length > 1) {
 		/*
 		 * Is the field an array of field names?

--- a/test/integration/get.spec.js
+++ b/test/integration/get.spec.js
@@ -181,17 +181,19 @@ describe(`Dare init tests: options ${Object.keys(options)}`, () => {
 	});
 
 	it('Can search via fulltext', async () => {
-		const username = 'A Name';
-		await dare.post('users', {
-			username,
-			first_name: 'First',
-			last_name: 'Last',
-		});
+		const username = 'name@example.com';
+		await dare.post('users', [
+			{
+				username,
+				first_name: "First Old'n'Name",
+				last_name: 'Last-Name',
+			},
+		]);
 
 		// Search across multiple fields
 		{
 			const resp = await dare.get('users', ['username'], {
-				'*username,first_name,last_name': 'Name Fir* Las*',
+				'*username,first_name,last_name': '+Fir* +Las*',
 			});
 			expect(resp).to.have.property('username', username);
 		}
@@ -202,7 +204,33 @@ describe(`Dare init tests: options ${Object.keys(options)}`, () => {
 				'username,first_name,last_name';
 
 			const resp = await dare.get('users', ['username'], {
-				'*textsearch': 'Name Fir* Las*',
+				'*textsearch': 'Fir* Las*',
+			});
+			expect(resp).to.have.property('username', username);
+		}
+
+		// And format the search to be compatible with MySQL Fulltext syntax
+
+		// Emails
+		{
+			const resp = await dare.get('users', ['username'], {
+				'*textsearch': username,
+			});
+			expect(resp).to.have.property('username', username);
+		}
+
+		// Hyphens
+		{
+			const resp = await dare.get('users', ['username'], {
+				'*textsearch': '+last-name',
+			});
+			expect(resp).to.have.property('username', username);
+		}
+
+		// Apostrophe's
+		{
+			const resp = await dare.get('users', ['username'], {
+				'*textsearch': "+Old'n'Name",
 			});
 			expect(resp).to.have.property('username', username);
 		}

--- a/test/specs/filter_reducer.spec.js
+++ b/test/specs/filter_reducer.spec.js
@@ -1,4 +1,6 @@
 import {expect} from 'chai';
+import Dare from '../../src/index.js';
+
 /*
  * Filter Reducer
  * Extract the filter conditions from the given conditions
@@ -17,7 +19,7 @@ describe('Filter Reducer', () => {
 
 	// Mock instance of Dare
 	beforeEach(() => {
-		dareInstance = {};
+		dareInstance = new Dare();
 		table_schema = {
 			textsearch: 'givenname,lastname,email',
 		};

--- a/test/specs/fulltext_parser.spec.js
+++ b/test/specs/fulltext_parser.spec.js
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import Dare from '../../src/index.js';
+
+describe('fulltextParser', () => {
+	// No formatting should be applied to these inputs
+	[
+		'foo bar',
+		'-foo +bar* ~"bar@  abar"',
+		'-foo +"bar foo bar"',
+		'-foo +(<"bar foo @ bar" >"bar bar foo")',
+	].forEach(input => {
+		it(`should leave untouched ${input}`, () => {
+			const dare = new Dare();
+			const output = dare.fulltextParser(input);
+			assert.strictEqual(
+				input,
+				output,
+				'input and output should be the same'
+			);
+		});
+	});
+
+	// These inputs should be fixed up
+	[
+		[
+			/*
+			 * Emails should be quoted
+			 * quoted strings not have an `*` appended
+			 * spurious + - characters should be removed
+			 */
+			'+email@example.com*    +"som eth"* +   - *    ',
+			'+"email@example.com" +"som eth"',
+		],
+		[
+			/*
+			 * Hyphens and apostrophes should be quoted
+			 * Items within parentheses should be maintained
+			 */
+			"+(>hit'n'miss <miss-n-hit) +",
+			'+(>"hit\'n\'miss" <"miss-n-hit")',
+		],
+	].forEach(([input, expected]) => {
+		it(`should parse ${input} -> ${expected}`, () => {
+			const dare = new Dare();
+			const output = dare.fulltextParser(input);
+			assert.strictEqual(
+				output,
+				expected,
+				'input and output should be the same'
+			);
+
+			// The output should not be changed on a second pass
+			const output2 = dare.fulltextParser(output);
+			assert.strictEqual(
+				output,
+				output2,
+				'output and output2 should be the same'
+			);
+		});
+	});
+
+	// These inputs should throw errors
+	['', null, undefined, 123, {}, [], true, false].forEach(input => {
+		it(`should throw an error on "${input}" (${typeof input})`, () => {
+			const dare = new Dare();
+			assert.throws(
+				() => {
+					// @ts-ignore
+					dare.fulltextParser(input);
+				},
+				{
+					message: 'Fulltext input must be a string',
+					name: 'Error',
+				}
+			);
+		});
+	});
+});


### PR DESCRIPTION
Parsers the FullText search text, ensuring common syntax mistakes are repaired

i.e.
- quoting inputs which use the `@` character, i.e. `email@example.com`, similarly hyphen `-` and apostrophe ','.
- removing spurious characters