### PR TITLE
feat(tableAliases): use only alphabetical characters, noissue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,14 +138,26 @@ Dare.prototype.table_alias_handler = function (name) {
 
 Dare.prototype.unique_alias_index = 0;
 
-Dare.prototype.get_unique_alias = function (iterate = 1) {
-	this.unique_alias_index += iterate;
+Dare.prototype.get_unique_alias = function () {
 	const i = this.unique_alias_index;
-	const str = String.fromCharCode(96 + i);
-	if (i <= 26) {
+	const num_characters_in_alphabet = 26;
+	const str = String.fromCharCode(97 + (i % num_characters_in_alphabet));
+	this.unique_alias_index += 1;
+	if (i < num_characters_in_alphabet) {
 		return str;
 	}
-	return `\`${str}\``;
+
+	if (i > num_characters_in_alphabet * num_characters_in_alphabet) {
+		throw new DareError(
+			DareError.INVALID_REQUEST,
+			'Unique Alias Index has exceeded maximum'
+		);
+	}
+
+	const prefix = String.fromCharCode(
+		96 + Math.floor(i / num_characters_in_alphabet)
+	);
+	return `\`${prefix}${str}\``;
 };
 
 // eslint-disable-next-line jsdoc/valid-types

--- a/test/specs/get_unique_alias.spec.js
+++ b/test/specs/get_unique_alias.spec.js
@@ -5,10 +5,13 @@ describe('get_unique_alias', () => {
 	it('should always return a unique alphabet character or a quoted value', () => {
 		const dare = new Dare();
 
-		for (let i = 0; i < 100; i++) {
+		for (let i = 0; i <= 26 * 26; i++) {
 			const alias = dare.get_unique_alias();
 			// eslint-disable-next-line security/detect-unsafe-regex
-			expect(alias).to.match(/^[a-z]+|(?<tick>`)?.\k<tick>$/);
+			expect(alias).to.match(/^[a-z]|(?<tick>`)[a-z]{2,}\k<tick>$/);
 		}
+
+		// Expect the next one to throw an error
+		expect(() => dare.get_unique_alias()).to.throw();
 	});
 });


### PR DESCRIPTION
Ensures we have human-readable characters within the generated SQL.