### PR TITLE
feat(field_expression): support [FUNCNAME](field AS [UPPERCASE|String])

### DIFF
--- a/src/utils/unwrap_field.js
+++ b/src/utils/unwrap_field.js
@@ -46,7 +46,7 @@ export default function unwrap_field(expression, allowValue = true) {
 			// Split out comma variables
 			while (
 				(int_m = str.match(
-					/^(.*)(,\s*(?<suffix>(?<quote>["'])?[\s\w%./-]*\k<quote>))$/i
+					/^(.*)((,|AS)\s*(?<suffix>(?<quote>["'])?[\s\w%./-]*\k<quote>))$/
 				))
 			) {
 				/*
@@ -64,7 +64,7 @@ export default function unwrap_field(expression, allowValue = true) {
 					);
 				}
 
-				str = int_m[1];
+				str = int_m[1].trim();
 				suffix = int_m[2] + suffix;
 			}
 
@@ -132,6 +132,8 @@ export default function unwrap_field(expression, allowValue = true) {
 			value: expression,
 		};
 	}
+
+
 
 	// Is this a valid field
 	throw new DareError(

--- a/test/specs/unwrap_field.spec.js
+++ b/test/specs/unwrap_field.spec.js
@@ -37,6 +37,8 @@ describe('utils/unwrap_field', () => {
 		'IF(field IS NULL, "yes", "no")',
 		'IF(field IS NOT NULL, "yes", "no")',
 		'COALESCE(field, "")',
+		'CAST(field AS SIGNED)',
+		'CONVERT(field , SIGNED)',
 		'NULLIF(field, "is null")',
 		'ROUND(field, 2)',
 		'ROUND(AVG(field) * 100, 2)',
@@ -69,6 +71,8 @@ describe('utils/unwrap_field', () => {
 		'field(',
 		'IF(field < "string"str, "yes", "no")',
 		'IF(field = \'string", "yes", "no")',
+		'IF(field, SELECT 1 FROM table)',
+		'IF(field, ""), SELECT 1 FROM table)',
 		'DATE_FORMAT(field, ',
 		'IF(field <<< 123, "yes", "no")',
 


### PR DESCRIPTION
Supports new syntax to allow the `AS` in place of a comma (`,`).

i.e. `CAST(field AS SIGNED)`