### PR TITLE
feat(alias-on-dup-update): use mysql 8.0.20+ VALUES(...) AS _new ON D…  b635110 …UP KEY a=_new.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,8 @@ import extend from './utils/extend.js';
 
 import clone from 'tricks/object/clone.js';
 
+import semverCompare from 'semver-compare';
+
 import format_request from './format_request.js';
 
 import response_handler, {responseRowHandler} from './response_handler.js';
@@ -1069,10 +1071,19 @@ Dare.prototype.onDuplicateKeysUpdate = function onDuplicateKeysUpdate(
 		`;
 	}
 
+	/*
+	 * MySQL 8.0.20+ deprecates VALUES() in ON DUPLICATE KEY UPDATE
+	 * Use row alias notation instead: AS _new ... _new.col
+	 */
+	const useAlias = this.engine.startsWith('mysql') &&
+		semverCompare(this.engine.split(':').at(1), '8.0.20') >= 0;
+
 	let s = keys
 		.map(
 			name =>
-				`${this.identifierWrapper(name)}=VALUES(${this.identifierWrapper(name)})`
+				useAlias
+					? `${this.identifierWrapper(name)}=_new.${this.identifierWrapper(name)}`
+					: `${this.identifierWrapper(name)}=VALUES(${this.identifierWrapper(name)})`
 		)
 		.join(',');
 
@@ -1081,7 +1092,7 @@ Dare.prototype.onDuplicateKeysUpdate = function onDuplicateKeysUpdate(
 		s = `${s}=${s}`;
 	}
 
-	return `ON DUPLICATE KEY UPDATE ${s}`;
+	return `${useAlias && keys.length ? 'AS _new ' : ''}ON DUPLICATE KEY UPDATE ${s}`;
 };
 
 /**

--- a/test/specs/field_alias.spec.js
+++ b/test/specs/field_alias.spec.js
@@ -285,6 +285,8 @@ describe('field alias', () => {
 
 	describe('post - INSERT', () => {
 		it('should map field aliases defined in the schema into INSERT body', async () => {
+
+			dare.engine = 'mysql:8.0.20';
 			let _sql = '';
 
 			// Stub the execute function
@@ -310,8 +312,8 @@ describe('field alias', () => {
 			assert.ok(_sql.includes('(`email`,`country_id`)'));
 
 			// ON DUPLICATE KEY UPDATE
-			assert.ok(_sql.includes('`email`=VALUES(`email`)'));
-			assert.ok(_sql.includes('`country_id`=VALUES(`country_id`)'));
+			assert.ok(_sql.includes('`email`=_new.`email`'));
+			assert.ok(_sql.includes('`country_id`=_new.`country_id`'));
 		});
 
 		it('should throw an error trying to post to a SQL Alias field', async () => {

--- a/test/specs/post.spec.js
+++ b/test/specs/post.spec.js
@@ -89,6 +89,8 @@ describe('post', () => {
 	it('should accept option.update=[field1, field2, ...fieldn]', async () => {
 		let called;
 
+		dare.engine = 'mysql:8.0.10';
+
 		dare.execute = async ({sql, values}) => {
 			called = 1;
 			sqlEqual(


### PR DESCRIPTION
> Update the ON DUPLICATE KEY to use the Alias notation as described in https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html when the version of MYSQL is 8.0.20 or more